### PR TITLE
Rewind the sound after `stop`

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -98,7 +98,7 @@ RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player stop];
-    [player setCurrentTime:0.0]
+    [player setCurrentTime:0.0];
   }
 }
 

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -98,6 +98,7 @@ RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player stop];
+    [player setCurrentTime:0.0]
   }
 }
 


### PR DESCRIPTION
When calling `stop` it resets the play position (without this it starts playing from where it stops)