### PR TITLE
Support for loading sounds from arbitrary directories on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
   }
 ```
 
-Save your sound clip files under the directory `android/app/src/main/res/raw` or any of the directories under Sound.
+Save your sound clip files under the directory `android/app/src/main/res/raw`, or any other directory in which case you need to pass the full path into the Sound constructor.
 
 ## Basic usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Native module for playing sound clips on iOS and Android.
 Feature | iOS | Android
 ---|---|---|---
 Load sound from the app bundle | ✓ | ✓
-Load sound from other directories | ✓ |
+Load sound from other directories | ✓ | ✓
 Load sound from the network | |
 Play sound | ✓ | ✓
 Playback completion callback | ✓ | ✓
@@ -86,7 +86,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
   }
 ```
 
-Save your sound clip files under the directory `android/app/src/main/res/raw`.
+Save your sound clip files under the directory `android/app/src/main/res/raw` or any of the directories under Sound.
 
 ## Basic usage
 

--- a/sound.js
+++ b/sound.js
@@ -7,6 +7,11 @@ var nextKey = 0;
 
 function Sound(filename, basePath, onError) {
   this._filename = basePath ? basePath + '/' + filename : filename;
+
+  if (IsAndroid && !basePath) {
+    this._filename = filename.toLowerCase().replace(/\.[^.]+$/, '');
+  }
+
   this._loaded = false;
   this._key = nextKey++;
   this._duration = -1;

--- a/sound.js
+++ b/sound.js
@@ -6,11 +6,7 @@ var IsAndroid = (typeof RNSound.setLooping) !== 'undefined';
 var nextKey = 0;
 
 function Sound(filename, basePath, onError) {
-  if (IsAndroid) {
-    this._filename = filename.toLowerCase().replace(/\.[^.]+$/, '');
-  } else {
-    this._filename = basePath ? basePath + '/' + filename : filename;
-  }
+  this._filename = basePath ? basePath + '/' + filename : filename;
   this._loaded = false;
   this._key = nextKey++;
   this._duration = -1;


### PR DESCRIPTION
Hi! This PR adds support for loading files on Android from arbitrary directories. This fixes #8 and fixes #5.

I tested loading a file from `RNFS.DocumentsDirectory` which worked perfectly.

Thanks!