### PR TITLE
Recognize a external file and a bundled file on Android.

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -5,10 +5,14 @@ var IsAndroid = RNSound.IsAndroid;
 
 var nextKey = 0;
 
+function isRelativePath(path) {
+  return !/^\//.test(path);
+}
+
 function Sound(filename, basePath, onError) {
   this._filename = basePath ? basePath + '/' + filename : filename;
 
-  if (IsAndroid && !basePath) {
+  if (IsAndroid && !basePath && isRelativePath(filename)) {
     this._filename = filename.toLowerCase().replace(/\.[^.]+$/, '');
   }
 


### PR DESCRIPTION
I fixed this.

Issue #27 
@zmxv commented below 
> @fritx You're right. I should probably check if filename is an absolute path in the if condition.

I would like to play a downloaded file the path of which is like below , but I can not.
/storage/emulated/0/Android/data/com.client/files/music/abc.mp3

It is necessary to check if filename is an absolute path or a relative one in the if condition.
