### PR TITLE
Support "requiring" audio files via RN assets system (iOS only)

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -64,25 +64,6 @@ RCT_EXPORT_METHOD(enable:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
-RCT_EXPORT_METHOD(setCategory:(nonnull NSNumber*)key withValue:(NSString*)categoryName) {
-  AVAudioSession *session = [AVAudioSession sharedInstance];
-  if ([categoryName isEqual: @"Ambient"]) {
-    [session setCategory: AVAudioSessionCategoryAmbient error: nil];
-  } else if ([categoryName isEqual: @"SoloAmbient"]) {
-    [session setCategory: AVAudioSessionCategorySoloAmbient error: nil];
-  } else if ([categoryName isEqual: @"Playback"]) {
-    [session setCategory: AVAudioSessionCategoryPlayback error: nil];
-  } else if ([categoryName isEqual: @"Record"]) {
-    [session setCategory: AVAudioSessionCategoryRecord error: nil];
-  } else if ([categoryName isEqual: @"PlayAndRecord"]) {
-    [session setCategory: AVAudioSessionCategoryPlayAndRecord error: nil];
-  } else if ([categoryName isEqual: @"AudioProcessing"]) {
-    [session setCategory: AVAudioSessionCategoryAudioProcessing error: nil];
-  } else if ([categoryName isEqual: @"MultiRoute"]) {
-    [session setCategory: AVAudioSessionCategoryMultiRoute error: nil];
-  }
-}
-
 RCT_EXPORT_METHOD(enableInSilenceMode:(BOOL)enabled) {
   AVAudioSession *session = [AVAudioSession sharedInstance];
   [session setCategory: AVAudioSessionCategoryPlayback error: nil];
@@ -93,7 +74,8 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
                   withCallback:(RCTResponseSenderBlock)callback) {
   NSError* error;
   AVAudioPlayer* player = [[AVAudioPlayer alloc]
-                           initWithContentsOfURL:[NSURL fileURLWithPath:fileName] error:&error];
+                           initWithContentsOfURL:[NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]]
+                           error:&error];
   if (player) {
     player.delegate = self;
     [player prepareToPlay];

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -64,6 +64,25 @@ RCT_EXPORT_METHOD(enable:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
+RCT_EXPORT_METHOD(setCategory:(nonnull NSNumber*)key withValue:(NSString*)categoryName) {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  if ([categoryName isEqual: @"Ambient"]) {
+    [session setCategory: AVAudioSessionCategoryAmbient error: nil];
+  } else if ([categoryName isEqual: @"SoloAmbient"]) {
+    [session setCategory: AVAudioSessionCategorySoloAmbient error: nil];
+  } else if ([categoryName isEqual: @"Playback"]) {
+    [session setCategory: AVAudioSessionCategoryPlayback error: nil];
+  } else if ([categoryName isEqual: @"Record"]) {
+    [session setCategory: AVAudioSessionCategoryRecord error: nil];
+  } else if ([categoryName isEqual: @"PlayAndRecord"]) {
+    [session setCategory: AVAudioSessionCategoryPlayAndRecord error: nil];
+  } else if ([categoryName isEqual: @"AudioProcessing"]) {
+    [session setCategory: AVAudioSessionCategoryAudioProcessing error: nil];
+  } else if ([categoryName isEqual: @"MultiRoute"]) {
+    [session setCategory: AVAudioSessionCategoryMultiRoute error: nil];
+  }
+}
+
 RCT_EXPORT_METHOD(enableInSilenceMode:(BOOL)enabled) {
   AVAudioSession *session = [AVAudioSession sharedInstance];
   [session setCategory: AVAudioSessionCategoryPlayback error: nil];

--- a/sound.js
+++ b/sound.js
@@ -10,9 +10,9 @@ function isRelativePath(path) {
 }
 
 function Sound(filename, basePath, onError) {
-  var image = resolveAssetSource(filename);
-  if (image) {
-    this._filename = image.uri;
+  var asset = resolveAssetSource(filename);
+  if (asset) {
+    this._filename = asset.uri;
     onError = basePath;
   } else {
     this._filename = basePath ? basePath + '/' + filename : filename;

--- a/sound.js
+++ b/sound.js
@@ -2,7 +2,7 @@
 
 var RNSound = require('react-native').NativeModules.RNSound;
 var IsAndroid = RNSound.IsAndroid;
-
+var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSource");
 var nextKey = 0;
 
 function isRelativePath(path) {
@@ -10,10 +10,16 @@ function isRelativePath(path) {
 }
 
 function Sound(filename, basePath, onError) {
-  this._filename = basePath ? basePath + '/' + filename : filename;
+  var image = resolveAssetSource(filename);
+  if (image) {
+    this._filename = image.uri;
+    onError = basePath;
+  } else {
+    this._filename = basePath ? basePath + '/' + filename : filename;
 
-  if (IsAndroid && !basePath && isRelativePath(filename)) {
-    this._filename = filename.toLowerCase().replace(/\.[^.]+$/, '');
+    if (IsAndroid && !basePath && isRelativePath(filename)) {
+      this._filename = filename.toLowerCase().replace(/\.[^.]+$/, '');
+    }
   }
 
   this._loaded = false;
@@ -133,11 +139,6 @@ Sound.prototype.setCurrentTime = function(value) {
     RNSound.setCurrentTime(this._key, value);
   }
   return this;
-};
-
-// ios only
-Sound.prototype.setCategory = function(value) {
-  RNSound.setCategory(this._key, value);
 };
 
 Sound.enable = function(enabled) {

--- a/sound.js
+++ b/sound.js
@@ -141,6 +141,11 @@ Sound.prototype.setCurrentTime = function(value) {
   return this;
 };
 
+// ios only
+Sound.prototype.setCategory = function(value) {
+  RNSound.setCategory(this._key, value);
+};
+
 Sound.enable = function(enabled) {
   RNSound.enable(enabled);
 };


### PR DESCRIPTION
This addresses #14 for iOS by adding support for using the RN assets system to `require` audio files that are placed alongside your JS components. I also fixed a bug where the iOS implementation wasn't correctly handling file paths that included URL encoded values (e.g. `%20`).

Additionally, I modified the `Sound` constructor signature to allow omitting the `basepath` argument if an asset value was specified, so that the following syntax can be achieved.

```javascript
var sound = new Sound(require("./foo.mp3"), (error) => {
   if (error) {
      // Handle error
   } else {
      sound.play();
   }
});
```

This PR currently only supports iOS, since the RN packager places the audio files into the `drawable-mpi` directory, as opposed to `raw` (where this plugin expects to find them) when generating an Android bundle. In general, the asset system on Android doesn't seem to really accommodate non-image assets at the moment. I'm going to investigate this and likely send a PR to RN itself, but I wanted to get this PR out to start the conversation.

I've got a local fork of RN that correctly writes audio files to the `raw` directory, and with this PR, `react-native-sound` works perfectly, so this PR should accommodate both iOS and Android, yet I'll need to submit a fix to RN to actually do the right thing for Android.

*NOTE: As an aside, this PR also allows you to ship updates to your audio files via OTA update services (e.g. CodePush), which is pretty awesome.*