### PR TITLE
Support the load of network stored files

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -92,9 +92,22 @@ RCT_EXPORT_METHOD(enableInSilenceMode:(BOOL)enabled) {
 RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
                   withCallback:(RCTResponseSenderBlock)callback) {
   NSError* error;
-  AVAudioPlayer* player = [[AVAudioPlayer alloc]
-                           initWithContentsOfURL:[NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]]
-                           error:&error];
+  NSURL* fileNameUrl;
+  AVAudioPlayer* player;
+  
+  if ([fileName hasPrefix:@"http"]) {
+    fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+  }
+  else {
+    fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
+  }
+    
+  if (fileNameUrl) {
+    player = [[AVAudioPlayer alloc]
+              initWithData:[[NSData alloc] initWithContentsOfURL:fileNameUrl]
+              error:&error];
+  }
+    
   if (player) {
     player.delegate = self;
     [player prepareToPlay];


### PR DESCRIPTION
This fix will support previously added `require(...)` of sounds from JS bundle while building project with loading assets from dev server.

Also, should support loading of sound from network, using object with `uri` as a first parameter of `Sound`:

```
const sound = new Sound({
    uri: 'http://some.file/from/internet.mp3',
});
```

**NB:** Works only with iOS, Android support not implemented!
