### PR TITLE
Update README: MainActivity -> MainApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ dependencies {
 }
 ```
 
-Edit `android/app/src/main/java/.../MainActivity.java` to register the native module:
+Edit `android/app/src/main/java/.../MainApplication.java` to register the native module:
 
 ```java
 ...
 import com.zmxv.RNSound.RNSoundPackage; // <-- New
 ...
 
-public class MainActivity extends ReactActivity {
+public class MainApplication extends Application implements ReactApplication {
   ...
   @Override
   protected List<ReactPackage> getPackages() {


### PR DESCRIPTION
Tested on a fresh install with react native 0.35

MainActivity doesn't have a method called getPackages for override, so that didn't make sense.