### PR TITLE
Android: Ensure any audio files that are playing when app exits are stopped & released

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -167,7 +167,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   /**
-   * Ensure any audios that are playing when app exits are stopped are released
+   * Ensure any audios that are playing when app exits are stopped and released
    */
   @Override
   public void onCatalystInstanceDestroy() {
@@ -181,6 +181,8 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       }
       try {
         mp.setOnCompletionListener(null);
+        mp.setOnPreparedListener(null);
+        mp.setOnErrorListener(null);
         if (mp.isPlaying()) {
           mp.stop();
         }


### PR DESCRIPTION
We noticed that on Android, if you attempt to pause an audio during the `componentWillUnmount` method of the root component, the pause method of RNSoundModule was never executed. In our case this was because the `react-native-sound` module was destroyed _before_ the JS -> Java message to pause the audio came through.

This PR automatically stops and releases all MediaPlayer instances when React Native shuts down. 

In the past, we've had odd exceptions during release of MediaPlayer, so the code below adopts a pretty defensive strategy.

Tested on Android 7.0, 6.0, and 4.4.4.