### PR TITLE
Support mixWithOthers on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ Return the loop count of the audio player. The default is `0` which means to pla
 ### `setCurrentTime(value)`
 `value` {number} Seek to a particular playback point in seconds.
 
-### `setCategory(value) (iOS only)`
+### `setCategory(value, mixWithOthers) (iOS only)`
 `value` {string} Sets AVAudioSession category, which allows playing sound in background, stop sound playback when phone is locked, etc. Parameter options: "Ambient", "SoloAmbient", "Playback", "Record", "PlayAndRecord", "AudioProcessing", "MultiRoute".
 
 More info about each category can be found in https://developer.apple.com/library/ios/documentation/AVFoundation/Reference/AVAudioSession_ClassReference/#//apple_ref/doc/constant_group/Audio_Session_Categories
+
+`mixWithOthers` {boolean} can be set to true to force mixing with other audio sessions.
 
 To play sound in the background, make sure to add the following to the `Info.plist` file.
 ```

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -64,22 +64,33 @@ RCT_EXPORT_METHOD(enable:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
-RCT_EXPORT_METHOD(setCategory:(nonnull NSNumber*)key withValue:(NSString*)categoryName) {
+RCT_EXPORT_METHOD(setCategory:(NSString *)categoryName
+    mixWithOthers:(BOOL)mixWithOthers) {
   AVAudioSession *session = [AVAudioSession sharedInstance];
+  NSString *category = nil;
+
   if ([categoryName isEqual: @"Ambient"]) {
-    [session setCategory: AVAudioSessionCategoryAmbient error: nil];
+    category = AVAudioSessionCategoryAmbient;
   } else if ([categoryName isEqual: @"SoloAmbient"]) {
-    [session setCategory: AVAudioSessionCategorySoloAmbient error: nil];
+    category = AVAudioSessionCategorySoloAmbient;
   } else if ([categoryName isEqual: @"Playback"]) {
-    [session setCategory: AVAudioSessionCategoryPlayback error: nil];
+    category = AVAudioSessionCategoryPlayback;
   } else if ([categoryName isEqual: @"Record"]) {
-    [session setCategory: AVAudioSessionCategoryRecord error: nil];
+    category = AVAudioSessionCategoryRecord;
   } else if ([categoryName isEqual: @"PlayAndRecord"]) {
-    [session setCategory: AVAudioSessionCategoryPlayAndRecord error: nil];
+    category = AVAudioSessionCategoryPlayAndRecord;
   } else if ([categoryName isEqual: @"AudioProcessing"]) {
-    [session setCategory: AVAudioSessionCategoryAudioProcessing error: nil];
+    category = AVAudioSessionCategoryAudioProcessing;
   } else if ([categoryName isEqual: @"MultiRoute"]) {
-    [session setCategory: AVAudioSessionCategoryMultiRoute error: nil];
+    category = AVAudioSessionCategoryMultiRoute;
+  }
+
+  if (category) {
+    if (mixWithOthers) {
+        [session setCategory: category withOptions:AVAudioSessionCategoryOptionMixWithOthers error: nil];
+    } else {
+      [session setCategory: category error: nil];
+    }
   }
 }
 

--- a/sound.js
+++ b/sound.js
@@ -142,9 +142,12 @@ Sound.prototype.setCurrentTime = function(value) {
 };
 
 // ios only
+
+// This is deprecated.  Call the static one instead.
+
 Sound.prototype.setCategory = function(value) {
-  RNSound.setCategory(this._key, value);
-};
+  Sound.setCategory(value, false);
+}
 
 Sound.enable = function(enabled) {
   RNSound.enable(enabled);
@@ -156,9 +159,11 @@ Sound.enableInSilenceMode = function(enabled) {
   }
 };
 
-if (!IsAndroid) {
-  Sound.enable(true);
-}
+Sound.setCategory = function(value, mixWithOthers) {
+  if (!IsAndroid) {
+    RNSound.setCategory(value, mixWithOthers);
+  }
+};
 
 Sound.MAIN_BUNDLE = RNSound.MainBundlePath;
 Sound.DOCUMENT = RNSound.NSDocumentDirectory;


### PR DESCRIPTION
The mixWithOthers option on iOS allows apps to specify that audio from
other sessions should be mixed in with the current app's session, even
in categories such as Playback.  We should support this option in the
library.

* Update the setCategory function to support an additional parameter
which sets the requisite withOptions parameter on setCategory.
* Remove the key parameter from setCategory since it wasn't being used.
* Add a static setCategory function in the JS.  For backwards
compatibility, the old version just calls this new function.  Also add
a guard so that android doesn't get borked.
* Remove the automatic call to enable since it gets called before the
category has been set up (which may lead to side effects), and is not
needed.
* Update docs.