### PR TITLE
Updated RCT imports for 0.40.0

### DIFF
--- a/RNSound/RNSound.h
+++ b/RNSound/RNSound.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <AVFoundation/AVFoundation.h>
 
 @interface RNSound : NSObject <RCTBridgeModule, AVAudioPlayerDelegate>

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -1,5 +1,5 @@
 #import "RNSound.h"
-#import "RCTUtils.h"
+#import <React/RCTUtils.h>
 
 @implementation RNSound {
   NSMutableDictionary* _playerPool;


### PR DESCRIPTION
Makes the changes to deal with iOS native headers being moved in react native 0.40 (https://github.com/facebook/react-native/releases/tag/v0.40.0)  __Note:__ this change makes the module not work on versions prior to 0.40.0.