### PR TITLE
RN iOS headers work on RN < 40 and RN >= 40

### DIFF
--- a/RNSound/RNSound.h
+++ b/RNSound/RNSound.h
@@ -1,4 +1,9 @@
-#import "RCTBridgeModule.h"
+#if __has_include("RCTBridgeModule.h")
+    #import "RCTBridgeModule.h"
+#else
+    #import <React/RCTBridgeModule.h>
+#endif
+
 #import <AVFoundation/AVFoundation.h>
 
 @interface RNSound : NSObject <RCTBridgeModule, AVAudioPlayerDelegate>

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -1,5 +1,10 @@
 #import "RNSound.h"
-#import "RCTUtils.h"
+
+#if __has_include("RCTUtils.h")
+    #import "RCTUtils.h"
+#else
+    #import <React/RCTUtils.h>
+#endif
 
 @implementation RNSound {
   NSMutableDictionary* _playerPool;


### PR DESCRIPTION
Use the backwards-compatible header import system outlined here: 
https://medium.com/@thisismissem/how-to-upgrade-react-native-modules-in-a-backwards-compatible-manner-a5b5c48d590c#.kf5p3b7of

.. so this library can work on both React Native < 0.40.0 and RN >= 0.40.0

Tested on React Native 0.39.2 and React Native 0.41.2