### PR TITLE
Added method for speaker playback on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Return the loop count of the audio player. The default is `0` which means to pla
 ### `setSpeakerphoneOn(value)`
 `speaker` {boolean} Sets the speakerphone on or off (Android Only).
 
+It requires this permission in your AndroidManifest: `<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>`
+
 ### `enableInSilenceMode(enabled)` (deprecated)
 `enabled` {boolean} Whether to enable playback in silence mode (iOS only).
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Return the loop count of the audio player. The default is `0` which means to pla
 ### `setSpeed(value)`
 `value` {number} Speed of the audio playback (iOS Only).
 
+### `setSpeakerphoneOn(value)`
+`speaker` {boolean} Sets the speakerphone on or off (Android Only).
+
 ### `enableInSilenceMode(enabled)` (deprecated)
 `enabled` {boolean} Whether to enable playback in silence mode (iOS only).
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -3,6 +3,7 @@ package com.zmxv.RNSound;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.media.MediaPlayer.OnErrorListener;
+import android.media.AudioManager;
 import android.net.Uri;
 
 import com.facebook.react.bridge.Arguments;
@@ -150,6 +151,21 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       return;
     }
     callback.invoke(player.getCurrentPosition() * .001, player.isPlaying());
+  }
+
+  @ReactMethod
+  public void setSpeakerphoneOn(final Integer key, final Boolean speaker) {
+    MediaPlayer player = this.playerPool.get(key);
+    if (player != null) {
+      player.setAudioStreamType(AudioManager.STREAM_MUSIC);
+      AudioManager audioManager = (AudioManager)this.context.getSystemService(this.context.AUDIO_SERVICE);
+      audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+      if (speaker == true) {
+        audioManager.setSpeakerphoneOn(true);
+      } else { 
+        audioManager.setSpeakerphoneOn(false);
+      }
+    }
   }
 
   @ReactMethod

--- a/sound.js
+++ b/sound.js
@@ -152,6 +152,13 @@ Sound.prototype.setCurrentTime = function(value) {
   return this;
 };
 
+// android only
+Sound.prototype.setSpeakerphoneOn = function(value) {
+  if (IsAndroid) {
+    RNSound.setSpeakerphoneOn(this._key, value);
+  }
+};
+
 // ios only
 
 // This is deprecated.  Call the static one instead.


### PR DESCRIPTION
related to https://github.com/zmxv/react-native-sound/issues/66

implemented the android version of this, using setSpeakerphoneOn's method of AudioManager: https://developer.android.com/reference/android/media/AudioManager.html#setSpeakerphoneOn(boolean)