### PR TITLE
Sound.prototype.play calls onEnd if sound isn't yet loaded

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -54,7 +54,6 @@ Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
     RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
   } else {
-    console.warn('Tried to play sound that was not yet loaded.');
     onEnd && onEnd(false);
   }
   return this;

--- a/sound.js
+++ b/sound.js
@@ -53,6 +53,9 @@ Sound.prototype.isLoaded = function() {
 Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
     RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
+  } else {
+    console.warn('Tried to play sound that was not yet loaded.');
+    onEnd && onEnd(false);
   }
   return this;
 };


### PR DESCRIPTION
Previously, calls to `Sound.prototype.play` would fail silently if the sound hadn't yet been loaded.
This change will ensure `onEnd(false)` is called in this situation, and a warning will be logged to the console.