### PR TITLE
Fix #124 - can now leave off Sound.setCategory mixWithOthers param 

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -170,7 +170,7 @@ Sound.enableInSilenceMode = function(enabled) {
   }
 };
 
-Sound.setCategory = function(value, mixWithOthers) {
+Sound.setCategory = function(value, mixWithOthers = false) {
   if (!IsAndroid) {
     RNSound.setCategory(value, mixWithOthers);
   }


### PR DESCRIPTION
See #124. Provides default to mixWithOthers parameter