### PR TITLE
IOS podspec - Adding React dependency to podspec

### DIFF
--- a/RNSound.podspec
+++ b/RNSound.podspec
@@ -13,7 +13,9 @@ Pod::Spec.new do |s|
   s.default_subspec     = 'Core'
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
-
+  
+  s.dependency 'React/Core'
+  
   s.subspec 'Core' do |ss|
     ss.source_files     = "RNSound/*.{h,m}"
   end


### PR DESCRIPTION
Necessary for RNSound when building a project that uses podfile (cocoapods). Without the above dependency, the build is failed with an error '<React/RCTDefines.h> file not found'.