### PR TITLE
Preprocessor if fix for tvOS

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -84,9 +84,13 @@ RCT_EXPORT_METHOD(setCategory:(NSString *)categoryName
     category = AVAudioSessionCategoryRecord;
   } else if ([categoryName isEqual: @"PlayAndRecord"]) {
     category = AVAudioSessionCategoryPlayAndRecord;
-  } else if ([categoryName isEqual: @"AudioProcessing"]) {
-    category = AVAudioSessionCategoryAudioProcessing;
-  } else if ([categoryName isEqual: @"MultiRoute"]) {
+  } 
+  #if TARGET_OS_IOS
+  else if ([categoryName isEqual: @"AudioProcessing"]) {
+      category = AVAudioSessionCategoryAudioProcessing;
+  }
+  #endif
+    else if ([categoryName isEqual: @"MultiRoute"]) {
     category = AVAudioSessionCategoryMultiRoute;
   }
 


### PR DESCRIPTION
tvOS does not have `AVAudioSessionCategoryAudioProcessing`, so we need to wrap it in a preprocessor that removes it for tvOS so it compiles for tvOS