### PR TITLE
[iOS] Fix crash in audioPlayerDidFinishPlaying when callback is called multiple times

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -45,9 +45,11 @@
                        successfully:(BOOL)flag {
   NSNumber* key = [self keyForPlayer:player];
   if (key != nil) {
-    RCTResponseSenderBlock callback = [self callbackForKey:key];
-    if (callback) {
-      callback(@[@(flag)]);
+    @synchronized(key) {
+      RCTResponseSenderBlock callback = [self callbackForKey:key];
+      if (callback) {
+        callback(@[@(flag)]);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #152. Probably also fixes #151.

<img width="487" alt="screenshot 2017-04-20 06 13 46" src="https://cloud.githubusercontent.com/assets/139536/25206699/b441fd1a-2593-11e7-8251-e89bb6018a7f.png">
