### PR TITLE
[Android] Fix race conditions in onCompletion and onError (This callback type only permits a single invocation from native code.)

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -76,7 +76,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     }
     player.setOnCompletionListener(new OnCompletionListener() {
       @Override
-      public void onCompletion(MediaPlayer mp) {
+      public synchronized void onCompletion(MediaPlayer mp) {
         if (!mp.isLooping()) {
           callback.invoke(true);
         }
@@ -84,7 +84,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     });
     player.setOnErrorListener(new OnErrorListener() {
       @Override
-      public boolean onError(MediaPlayer mp, int what, int extra) {
+      public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
         callback.invoke(false);
         return true;
       }


### PR DESCRIPTION
Fixes #106 - Illegal callback invocation from native module. This callback type only permits a single invocation from native code.

Inspired by: https://github.com/ivpusic/react-native-image-crop-picker/issues/235