### PR TITLE
Remove player.prepare() of prepare() in android native module

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -44,17 +44,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       callback.invoke(e);
       return;
     }
-    try {
-      player.prepare();
-    } catch (Exception exception) {
-              Log.e("RNSoundModule", "Exception", exception);
-
-       WritableMap e = Arguments.createMap();
-        e.putInt("code", -1);
-        e.putString("message", exception.getMessage());
-        callback.invoke(e);
-        return;
-    }
     this.playerPool.put(key, player);
     WritableMap props = Arguments.createMap();
     props.putDouble("duration", player.getDuration() * .001);


### PR DESCRIPTION
`android.media.MediaPlayer.prepare()` is not necessary because [create()](https://github.com/zmxv/react-native-sound/blob/master/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java#L85) method call it automatically.
Also,  [player.prepare()](https://github.com/zmxv/react-native-sound/blob/master/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java#L48) code in `RNSoundModule.java` throws an exception with `{ code: -1, message: null }` with my device (Galaxy S7 edge, Android 7.0) and avd (Android 6.0 Google APIs, x86).
Since I removed `player.prepare()`, the error has gone. 

- <a href="https://developer.android.com/reference/android/media/MediaPlayer.html#create(android.content.Context, android.net.Uri)">reference</a>