### PR TITLE
Added callbacks to stop and pause, because the RN bridge is asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ whoosh.getCurrentTime((seconds) => console.log('at ' + seconds));
 whoosh.pause();
 
 // Stop the sound and rewind to the beginning
-whoosh.stop();
+whoosh.stop(() => {
+  // Note: If you want to play a sound after stopping and rewinding it,
+  // it is important to call play() in a callback.
+  whoosh.play();
+});
 
 // Release the audio player resource
 whoosh.release();
@@ -196,13 +200,17 @@ whoosh.release();
 Return `true` if the sound has been loaded.
 
 ### `play(onEnd)`
-`onEnd` {?function(successfully)} Optinoal callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it.
+`onEnd` {?function(successfully)} Optional callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it.
 
-### `pause()`
+### `pause(callback)`
+`callback` {?function()} Optional callback function that gets called when the sound has been paused.
+
 Pause the sound.
 
-### `stop()`
-Stop the playback.
+### `stop(callback)`
+`callback` {?function()} Optional callback function that gets called when the sound has been stopped.
+
+Stop playback and set the seek position to 0.
 
 ### `release()`
 Release the audio player resource associated with the instance.

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -150,18 +150,20 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   }
 }
 
-RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)key) {
+RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlock)callback) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player pause];
+    callback(@[]);
   }
 }
 
-RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key) {
+RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlock)callback) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player stop];
     player.currentTime = 0;
+    callback(@[]);
   }
 }
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -116,20 +116,22 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void pause(final Integer key) {
+  public void pause(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
     }
+    callback.invoke();
   }
 
   @ReactMethod
-  public void stop(final Integer key) {
+  public void stop(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
       player.seekTo(0);
     }
+    callback.invoke();
   }
 
   @ReactMethod

--- a/sound.js
+++ b/sound.js
@@ -60,16 +60,16 @@ Sound.prototype.play = function(onEnd) {
   return this;
 };
 
-Sound.prototype.pause = function() {
+Sound.prototype.pause = function(callback) {
   if (this._loaded) {
-    RNSound.pause(this._key);
+    RNSound.pause(this._key, () => { callback && callback() });
   }
   return this;
 };
 
-Sound.prototype.stop = function() {
+Sound.prototype.stop = function(callback) {
   if (this._loaded) {
-    RNSound.stop(this._key);
+    RNSound.stop(this._key, () => { callback && callback() });
   }
   return this;
 };

--- a/windows/RNSoundModule/RNSoundModule/RNSound.cs
+++ b/windows/RNSoundModule/RNSoundModule/RNSound.cs
@@ -175,7 +175,7 @@ namespace RNSoundModule
         }
 
         [ReactMethod]
-        public void pause(int key)
+        public void pause(int key, ICallback callback)
         {
             MediaPlayer player = null;
 
@@ -187,10 +187,11 @@ namespace RNSoundModule
             {
                 player.Pause();
             }
+            callback.Invoke();
         }
 
         [ReactMethod]
-        public void stop(int key)
+        public void stop(int key, ICallback callback)
         {
             MediaPlayer player = null;
 
@@ -201,6 +202,7 @@ namespace RNSoundModule
 
             player.Pause();
             player.PlaybackSession.Position = new TimeSpan(0);
+            callback.Invoke();
         }
 
         [ReactMethod]


### PR DESCRIPTION
For 99% of my sound effects, I just want to play them from the beginning. If something is already playing, I almost always want to rewind and start from the beginning.

I had assumed that I could do this with:

```js
sound.stop()
sound.play()
```

But then I noticed that sometimes my sounds were being clipped in strange ways. I just learned that the React Native Bridge is asynchronous, so `stop` and `play` are effectively being called in parallel.

This change allows me to call:

```js
sound.stop(() => { sound.play() })
```

... which lets me make sure that a sound is rewinded before playing it.

### Disclaimer

I haven't been able to test the Windows version, and that's the first time I've ever written any C#. But I'm currently in the middle of setting up a Windows installation for RN development, so I might be able to report back in a few hours.