### PR TITLE
Fix callback crashes - Guarantee that the RN callback is only ever called once

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -44,12 +44,13 @@
 -(void) audioPlayerDidFinishPlaying:(AVAudioPlayer*)player
                        successfully:(BOOL)flag {
   NSNumber* key = [self keyForPlayer:player];
-  if (key != nil) {
-    @synchronized(key) {
-      RCTResponseSenderBlock callback = [self callbackForKey:key];
-      if (callback) {
-        callback(@[@(flag)]);
-      }
+  if (key == nil) return;
+
+  @synchronized(key) {
+    RCTResponseSenderBlock callback = [self callbackForKey:key];
+    if (callback) {
+      callback(@[@(flag)]);
+      [[self callbackPool] removeObjectForKey:key];
     }
   }
 }

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -98,16 +98,24 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       return;
     }
     player.setOnCompletionListener(new OnCompletionListener() {
+      boolean callbackWasCalled = false;
+
       @Override
       public synchronized void onCompletion(MediaPlayer mp) {
         if (!mp.isLooping()) {
+          if (callbackWasCalled) return;
+          callbackWasCalled = true;
           callback.invoke(true);
         }
       }
     });
     player.setOnErrorListener(new OnErrorListener() {
+      boolean callbackWasCalled = false;
+
       @Override
       public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
+        if (callbackWasCalled) return true;
+        callbackWasCalled = true;
         callback.invoke(false);
         return true;
       }

--- a/windows/RNSoundModule/RNSoundModule/RNSound.cs
+++ b/windows/RNSoundModule/RNSoundModule/RNSound.cs
@@ -142,6 +142,7 @@ namespace RNSoundModule
         [ReactMethod]
         public void play(int key, ICallback callback)
         {
+            Boolean callbackWasCalled = false;
             MediaPlayer player = null;
             Debug.WriteLine("play()");
 
@@ -167,6 +168,8 @@ namespace RNSoundModule
             player.MediaEnded +=
                 delegate
                 {
+                    if (callbackWasCalled) return;
+                    callbackWasCalled = true;
                     Debug.WriteLine("Media Ended");
                     callback.Invoke(true);
                 };


### PR DESCRIPTION
I previously added the `synchronized` calls to make sure that the callbacks were only being called one at a time. That was actually not enough. I was developing some other RN libraries, and I realized that I should have paid more attention to the error message... these callbacks actually can only be called once. It doesn't matter if there is a race condition or not, if you call them twice, the app will crash. 

So the `synchronized` calls did help to reduce the number of crashes in my app, but I still experienced one or two crashes, and this PR will completely stop them from happening.

On iOS, I am removing the callback from the pool as soon as it is called. On Android, I added an extra boolean flag inside the listener, so that the callback can only ever be called once.

**Note:** I haven't looked at Windows yet, but I'm about to set up a development environment, so I will take a look soon.