### PR TITLE
Properly handling ipod-library:// urls coming from itunes

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -118,7 +118,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
   NSURL* fileNameUrl;
   AVAudioPlayer* player;
   
-  if ([fileName hasPrefix:@"http"]) {
+  if ([fileName hasPrefix:@"http"] || [fileName hasPrefix:@"ipod-library://"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
   }
   else {


### PR DESCRIPTION
This exact patch is untested, sorry, but I back-ported it from an experiment I made to use react-native-sound with react-native-itunes.
