### PR TITLE
Added the ability to configure "SMTC integration" for Windows apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,16 @@ whoosh.release();
 ```
 
 ## API
-### `constructor(filename, basePath, onError)`
+### `constructor(filename, basePath, onError, options)`
 `filename` {string} Either absolute or relative path to the sound file
 
 `basePath` {?string} Optional base path of the file. Omit this or pass `''` if `filename` is an absolute path. Otherwise, you may use one of the predefined directories: `Sound.MAIN_BUNDLE`, `Sound.DOCUMENT`, `Sound.LIBRARY`, `Sound.CACHES`.
 
 `onError` {?function(error, props)} Optional callback function. If the file is successfully loaded, the first parameter `error` is `null`, and `props` contains an object with two properties: `duration` (in seconds) and `numberOfChannels` (`1` for mono and `2` for stereo sound), both of which can also be accessed from the `Sound` instance object. If an initialization error is encountered (e.g. file not found), `error` will be an object containing `code`, `description`, and the stack trace.
+
+`options` {?object} Platform-specific options:
+
+**Windows Only:** `enableSMTCIntegration` {?boolean}. Optional setting for windows to enable or disable SMTC integration (controlling your apps sounds or music via the keyboard, and the built-in media controls on Windows.) This is enabled by default. Set this to false when you don't want users to be able to control your sounds (e.g. sound effects.) See the [Windows.Media.SystemMediaTransportControls documentation](https://docs.microsoft.com/en-us/uwp/api/Windows.Media.SystemMediaTransportControls) for more information.
 
 ### `isLoaded()`
 Return `true` if the sound has been loaded.

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(setCategory:(NSString *)categoryName
     category = AVAudioSessionCategoryRecord;
   } else if ([categoryName isEqual: @"PlayAndRecord"]) {
     category = AVAudioSessionCategoryPlayAndRecord;
-  } 
+  }
   #if TARGET_OS_IOS
   else if ([categoryName isEqual: @"AudioProcessing"]) {
       category = AVAudioSessionCategoryAudioProcessing;
@@ -112,25 +112,27 @@ RCT_EXPORT_METHOD(enableInSilenceMode:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
-RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
+RCT_EXPORT_METHOD(prepare:(NSString*)fileName
+                  withKey:(nonnull NSNumber*)key
+                  withOptions:(NSDictionary*)options
                   withCallback:(RCTResponseSenderBlock)callback) {
   NSError* error;
   NSURL* fileNameUrl;
   AVAudioPlayer* player;
-  
+
   if ([fileName hasPrefix:@"http"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
   }
   else {
     fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
   }
-    
+
   if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
               initWithData:[[NSData alloc] initWithContentsOfURL:fileNameUrl]
               error:&error];
   }
-    
+
   if (player) {
     player.delegate = self;
     player.enableRate = YES;

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.File;
@@ -35,7 +36,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void prepare(final String fileName, final Integer key, final Callback callback) {
+  public void prepare(final String fileName, final Integer key, final ReadableMap options, final Callback callback) {
     MediaPlayer player = createMediaPlayer(fileName);
     if (player == null) {
       WritableMap e = Arguments.createMap();

--- a/sound.js
+++ b/sound.js
@@ -10,7 +10,7 @@ function isRelativePath(path) {
   return !/^(\/|http(s?))/.test(path);
 }
 
-function Sound(filename, basePath, onError) {
+function Sound(filename, basePath, onError, options) {
   var asset = resolveAssetSource(filename);
   if (asset) {
     this._filename = asset.uri;
@@ -31,7 +31,7 @@ function Sound(filename, basePath, onError) {
   this._pan = 0;
   this._numberOfLoops = 0;
   this._speed = 1;
-  RNSound.prepare(this._filename, this._key, (error, props) => {
+  RNSound.prepare(this._filename, this._key, options || {}, (error, props) => {
     if (props) {
       if (typeof props.duration === 'number') {
         this._duration = props.duration;


### PR DESCRIPTION
### This change solves the following problem:

I was testing my game on Windows, and I pressed the "play" key on my keyboard, because I wanted to unpause a song on Spotify. Instead of unpausing Spotify, my game took over the controls and one of the sound effects randomly started playing.

This change allows me to disable the "SMTC integration" on Windows for all of my sound effects, so that my game stops pretending to be a music player.

More information at: https://docs.microsoft.com/en-us/uwp/api/Windows.Media.SystemMediaTransportControls

The way I've written this is not very pretty, but it's backwards compatible. But I can imagine a nicer way to deal with platform-specific options like this, so that it's easier to add more in the future. The JS constructor could also use some work - I find the arguments very confusing.

Also note that this can't be a global setting. It needs to be configurable for each individual sound. For example, you might have some sound effects that you don't want the user to control, but you also play some songs that they *should* be able to control.