### PR TITLE
Must call prepare or prepareAsync when instantiating a new MediaPlayer and not using create()

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -61,6 +61,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       Log.i("RNSoundModule", fileName);
       try {
         mediaPlayer.setDataSource(fileName);
+        mediaPlayer.prepareAsync();
       } catch(IOException e) {
         Log.e("RNSoundModule", "Exception", e);
         return null;


### PR DESCRIPTION
Android URL support was broken by #162 (no sounds were playing), so this is the fix for that.