### PR TITLE
Use [AVAudioPlayer initWithContentsOfURL] directly, instead of NSData

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -127,7 +127,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
     
   if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
-              initWithData:[[NSData alloc] initWithContentsOfURL:fileNameUrl]
+              initWithContentsOfURL:fileNameUrl
               error:&error];
   }
     


### PR DESCRIPTION
This enables AVAudioPlayer to attempt to infer the filetype from the extension in the URL, which sometimes makes the difference between playback and an error.

This was the original behavior before 882c663c331f8177cc2d3d01dc8163cbd854ba70 introduced the intermediate call to `[NSData initWithContentsOfURL]` on February 14, 2017.