### PR TITLE
Add method to turn on speakers in android

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ Return the loop count of the audio player. The default is `0` which means to pla
 ### `setSpeed(value)`
 `value` {number} Speed of the audio playback (iOS Only).
 
+### `setSpeakerphoneOn(value)`
+`speaker` {boolean} Sets the speakerphone on or off (Android only).
+
+It requires this permission in your AndroidManifest: `<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>`
+
 ### `enableInSilenceMode(enabled)` (deprecated)
 `enabled` {boolean} Whether to enable playback in silence mode (iOS only).
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -182,6 +182,18 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     callback.invoke(player.getCurrentPosition() * .001, player.isPlaying());
   }
 
+  //turn speaker on
+  @ReactMethod
+  public void setSpeakerphoneOn(final Integer key, final Boolean speaker) {
+    MediaPlayer player = this.playerPool.get(key);
+    if (player != null) {
+      player.setAudioStreamType(AudioManager.STREAM_MUSIC);
+      AudioManager audioManager = (AudioManager)this.context.getSystemService(this.context.AUDIO_SERVICE);
+      audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+      audioManager.setSpeakerphoneOn(speaker);
+    }
+  }
+
   @ReactMethod
   public void enable(final Boolean enabled) {
     // no op

--- a/sound.js
+++ b/sound.js
@@ -155,6 +155,13 @@ Sound.prototype.setCurrentTime = function(value) {
   return this;
 };
 
+// android only
+Sound.prototype.setSpeakerphoneOn = function(value) {
+  if (IsAndroid) {
+    RNSound.setSpeakerphoneOn(this._key, value);
+  }
+};
+
 // ios only
 
 // This is deprecated.  Call the static one instead.


### PR DESCRIPTION
As requested at https://github.com/zmxv/react-native-sound/pull/121, I am uploading the simplified version of the set speaker on function.