### PR TITLE
Fix iOS download of remote files zmxv/react-native-sound#199

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -122,7 +122,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
 
   if ([fileName hasPrefix:@"http"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
-    NSData* data = [NSData dataWithContentsOfURL:fileNameUrl] ;
+    NSData* data = [NSData dataWithContentsOfURL:fileNameUrl];
     player = [[AVAudioPlayer alloc] initWithData:data error:&error];
   }
   else {

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -122,14 +122,13 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
 
   if ([fileName hasPrefix:@"http"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+    NSData* data = [NSData dataWithContentsOfURL:fileNameUrl] ;
+    player = [[AVAudioPlayer alloc] initWithData:data error:&error];
   }
   else {
     fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
-  }
-
-  if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
-              initWithContentsOfURL:fileNameUrl
+               initWithContentsOfURL:fileNameUrl
               error:&error];
   }
 

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
   else {
     fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
     player = [[AVAudioPlayer alloc]
-               initWithContentsOfURL:fileNameUrl
+              initWithContentsOfURL:fileNameUrl
               error:&error];
   }
 


### PR DESCRIPTION
Currently the remote playing of .aac/.mp3 files etc is broken on iOS. This patch fixes that. It may not necessarily be the best way to fix it though... however, it does work! 