### PR TITLE
Implement setAudioStream in Android and setSpeakerphoneOn in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,14 @@ Return the loop count of the audio player. The default is `0` which means to pla
 `value` {number} Speed of the audio playback (iOS Only).
 
 ### `setSpeakerphoneOn(value)`
-`speaker` {boolean} Sets the speakerphone on or off (Android only).
+`speaker` {boolean} Sets the speakerphone on or off (Android and iOS only).
 
 It requires this permission in your AndroidManifest: `<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>`
+
+### `setAudioStream(value)`
+`value` {string} Sets MediaPlayer audio stream type (Android only).
+
+Parameter options: "ALARM", "DTMF", "MUSIC", "NOTIFICATION", "RING", "SYSTEM", "VOICE_CALL".
 
 ### `enableInSilenceMode(enabled)` (deprecated)
 `enabled` {boolean} Whether to enable playback in silence mode (iOS only).

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -224,4 +224,14 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
   }
 }
 
+RCT_EXPORT_METHOD(setSpeakerphoneOn:(BOOL)enabled) {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  NSError *error = nil;
+  if (enabled) {
+    [session  overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
+  } else {
+    [session  overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
+  }
+}
+
 @end

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -38,6 +38,27 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void prepare(final String fileName, final Integer key, final ReadableMap options, final Callback callback) {
+    int audioStreamType = AudioManager.STREAM_MUSIC;
+    if (options.hasKey("audioStreamType")) {
+      String audioStreamTypeStr = options.getString("audioStreamType");
+      if (audioStreamTypeStr.equals("ALARM")) {
+        audioStreamType = AudioManager.STREAM_ALARM;
+      } else if (audioStreamTypeStr.equals("DTMF")) {
+        audioStreamType = AudioManager.STREAM_DTMF;
+      } else if (audioStreamTypeStr.equals("MUSIC")) {
+        audioStreamType = AudioManager.STREAM_MUSIC;
+      } else if (audioStreamTypeStr.equals("NOTIFICATION")) {
+        audioStreamType = AudioManager.STREAM_NOTIFICATION;
+      } else if (audioStreamTypeStr.equals("RING")) {
+        audioStreamType = AudioManager.STREAM_RING;
+      } else if (audioStreamTypeStr.equals("SYSTEM")) {
+        audioStreamType = AudioManager.STREAM_SYSTEM;
+      } else if (audioStreamTypeStr.equals("VOICE_CALL")) {
+        audioStreamType = AudioManager.STREAM_VOICE_CALL;
+      } else {
+        audioStreamType = AudioManager.STREAM_MUSIC;
+      }
+    }
     MediaPlayer player = createMediaPlayer(fileName);
     if (player == null) {
       WritableMap e = Arguments.createMap();
@@ -47,6 +68,8 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     }
 
     final RNSoundModule module = this;
+    
+    player.setAudioStreamType(audioStreamType);
 
     player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       boolean callbackWasCalled = false;
@@ -100,11 +123,18 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   protected MediaPlayer createMediaPlayer(final String fileName) {
     int res = this.context.getResources().getIdentifier(fileName, "raw", this.context.getPackageName());
     if (res != 0) {
-      return MediaPlayer.create(this.context, res);
+      String resFilename = "android.resource://" + this.context.getPackageName() + "/raw/" + fileName;
+      MediaPlayer mediaPlayer = new MediaPlayer();
+      try {
+        mediaPlayer.setDataSource(this.context, Uri.parse(resFilename));
+      } catch(IOException e) {
+        Log.e("RNSoundModule", "Exception", e);
+        return null;
+      }
+      return mediaPlayer;
     }
     if(fileName.startsWith("http://") || fileName.startsWith("https://")) {
       MediaPlayer mediaPlayer = new MediaPlayer();
-      mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
       Log.i("RNSoundModule", fileName);
       try {
         mediaPlayer.setDataSource(fileName);
@@ -118,8 +148,14 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     File file = new File(fileName);
     if (file.exists()) {
       Uri uri = Uri.fromFile(file);
-      // Mediaplayer is already prepared here.
-      return MediaPlayer.create(this.context, uri);
+      MediaPlayer mediaPlayer = new MediaPlayer();
+      try {
+        mediaPlayer.setDataSource(this.context, uri);
+      } catch(IOException e) {
+        Log.e("RNSoundModule", "Exception", e);
+        return null;
+      }
+      return mediaPlayer;
     }
     return null;
   }
@@ -239,9 +275,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   public void setSpeakerphoneOn(final Integer key, final Boolean speaker) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
-      player.setAudioStreamType(AudioManager.STREAM_MUSIC);
       AudioManager audioManager = (AudioManager)this.context.getSystemService(this.context.AUDIO_SERVICE);
-      audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
       audioManager.setSpeakerphoneOn(speaker);
     }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@
 // TypeScript Version: 2.3.2
 
 type AVAudioSessionCategory = 'Ambient' | 'SoloAmbient' | 'Playback' | 'Record' | 'PlayAndRecord' | 'AudioProcessing' | 'MultiRoute'
+type AudioManagerAudioStreamType = 'ALARM' | 'DTMF' | 'MUSIC' | 'NOTIFICATION' | 'RING' | 'SYSTEM' | 'VOICE_CALL'
 
 export default class Sound {
   static MAIN_BUNDLE: string
@@ -25,8 +26,9 @@ export default class Sound {
    * @param filename Either absolute or relative path to the sound file
    * @param basePath Optional base path of the file. Omit this or pass '' if filename is an absolute path. Otherwise, you may use one of the predefined directories: Sound.MAIN_BUNDLE, Sound.DOCUMENT, Sound.LIBRARY, Sound.CACHES.
    * @param onError Optional callback function if loading file failed
+   * @param options Optional feature 
    */
-  constructor(filename: string, basePath: string, onError: (error: any) => void)
+  constructor(filename: string, basePath: string, onError: (error: any) => void, options: { audioStreamType: AudioManagerAudioStreamType })
 
   /**
    * Return true if the sound has been loaded.

--- a/sound.js
+++ b/sound.js
@@ -159,6 +159,8 @@ Sound.prototype.setCurrentTime = function(value) {
 Sound.prototype.setSpeakerphoneOn = function(value) {
   if (IsAndroid) {
     RNSound.setSpeakerphoneOn(this._key, value);
+  } else if (!IsAndroid && !IsWindows) {
+    RNSound.setSpeakerphoneOn(value);
   }
 };
 


### PR DESCRIPTION
* This implements setAudioStream in Android.
* This implements setSpeakerphoneOn in iOS.

* This changes is needed to support playing sound via earpiece speaker or default speaker.
  * Android: `setAudioStream('VOICE_CALL')` && `setSpeakerphoneOn(true)` or `setSpeakerphoneOn(false)`
  * iOS: `setCategory('PlayAndRecord')` && `setSpeakerphoneOn(true)` or `setSpeakerphoneOn(false)`