### PR TITLE
Always use main thread

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -11,6 +11,10 @@
   NSMutableDictionary* _callbackPool;
 }
 
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
 -(NSMutableDictionary*) playerPool {
   if (!_playerPool) {
     _playerPool = [NSMutableDictionary new];


### PR DESCRIPTION
I couldn't find any definitive evidence that `AVAudioPlayer` is threadsafe, and I've encountered unusual race conditions where the `[player pause]` call fails to actually pause the underlying player. Serializing all manipulation of the playback state onto the main thread seems to alleviate this.

The only risk of regression I can imagine from this change is that loading large files may block the main thread. I'm open to discussion about the risks here.