### PR TITLE
Add Sound.setActive and Sound.setMode for iOS AVAudioSession support

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,20 @@ To play sound in the background, make sure to add the following to the `Info.pli
 </array>
 ```
 
+### `Sound.setMode(value) (iOS only)`
+
+`value` {string} Sets AVAudioSession mode, which works in conjunction with the category to determine audio mixing behavior. Parameter options: "Default", "VoiceChat", "VideoChat", "GameChat", "VideoRecording", "Measurement", "MoviePlayback", "SpokenAudio".
+
+This should be called in conjunction with `Sound.setCategory`.
+
+More info about each mode can be found in https://developer.apple.com/documentation/avfoundation/avaudiosession/audio_session_modes
+
+### `Sound.setActive(value) (iOS only)`
+
+Sets AVAudioSession as active, which is recommended on iOS to achieve seamless background playback.
+Use this method to deactivate the AVAudioSession when playback is finished in order for other apps
+to regain access to the audio stack.
+
 ## Notes
 - To minimize playback delay, you may want to preload a sound file without calling `play()` (e.g. `var s = new Sound(...);`) during app initialization. This also helps avoid a race condition where `play()` may be called before loading of the sound is complete, which results in no sound but no error because loading is still being processed.
 - You can play multiple sound files at the same time. Under the hood, this module uses `AVAudioSessionCategoryAmbient` to mix sounds on iOS.

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -72,6 +72,38 @@ RCT_EXPORT_METHOD(enable:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
+RCT_EXPORT_METHOD(setActive:(BOOL)active) {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  [session setActive: active error: nil];
+}
+
+RCT_EXPORT_METHOD(setMode:(NSString *)modeName) {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  NSString *mode = nil;
+
+  if ([modeName isEqual: @"Default"]) {
+    mode = AVAudioSessionModeDefault;
+  } else if ([modeName isEqual: @"VoiceChat"]) {
+    mode = AVAudioSessionModeVoiceChat;
+  } else if ([modeName isEqual: @"VideoChat"]) {
+    mode = AVAudioSessionModeVideoChat;
+  } else if ([modeName isEqual: @"GameChat"]) {
+    mode = AVAudioSessionModeGameChat;
+  } else if ([modeName isEqual: @"VideoRecording"]) {
+    mode = AVAudioSessionModeVideoRecording;
+  } else if ([modeName isEqual: @"Measurement"]) {
+    mode = AVAudioSessionModeMeasurement;
+  } else if ([modeName isEqual: @"MoviePlayback"]) {
+    mode = AVAudioSessionModeMoviePlayback;
+  } else if ([modeName isEqual: @"SpokenAudio"]) {
+    mode = AVAudioSessionModeSpokenAudio;
+  }
+
+  if (mode) {
+    [session setMode: mode error: nil];
+  }
+}
+
 RCT_EXPORT_METHOD(setCategory:(NSString *)categoryName
     mixWithOthers:(BOOL)mixWithOthers) {
   AVAudioSession *session = [AVAudioSession sharedInstance];

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,23 @@
 
 type AVAudioSessionCategory = 'Ambient' | 'SoloAmbient' | 'Playback' | 'Record' | 'PlayAndRecord' | 'AudioProcessing' | 'MultiRoute'
 
+type AVAudioSessionMode = 'Default' | 'VoiceChat' | 'VideoChat' | 'GameChat' | 'VideoRecording' | 'Measurement' | 'MoviePlayback' | 'SpokenAudio'
+
 export default class Sound {
   static MAIN_BUNDLE: string
   static DOCUMENT: string
   static LIBRARY: string
   static CACHES: string
+
+  /**
+   * Sets AVAudioSession as active, which is recommended on iOS to achieve seamless background playback.
+   * Use this method to deactivate the AVAudioSession when playback is finished in order for other apps
+   * to regain access to the audio stack.
+   * 
+   * @param category AVAudioSession category
+   * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
+   */
+  static setActive(active: boolean): void
 
   /**
    * Sets AVAudioSession category, which allows playing sound in background, 
@@ -20,6 +32,15 @@ export default class Sound {
    * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
    */
   static setCategory(category: AVAudioSessionCategory, mixWithOthers: boolean): void
+
+  /**
+   * Sets AVAudioSession mode, which works in conjunction with the category to determine audio mixing behavior.
+   * Parameter options: "Default", "VoiceChat", "VideoChat", "GameChat", "VideoRecording", "Measurement", "MoviePlayback", "SpokenAudio".
+   * 
+   * @param mode AVAudioSession mode
+   * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
+   */
+  static setMode(mode: AVAudioSessionMode): void
 
   /**
    * @param filename Either absolute or relative path to the sound file

--- a/sound.js
+++ b/sound.js
@@ -180,9 +180,21 @@ Sound.enableInSilenceMode = function(enabled) {
   }
 };
 
+Sound.setActive = function(value) {
+  if (!IsAndroid && !IsWindows) {
+    RNSound.setActive(value);
+  }
+};
+
 Sound.setCategory = function(value, mixWithOthers = false) {
   if (!IsAndroid && !IsWindows) {
     RNSound.setCategory(value, mixWithOthers);
+  }
+};
+
+Sound.setMode = function(value) {
+  if (!IsAndroid && !IsWindows) {
+    RNSound.setMode(value);
   }
 };
 


### PR DESCRIPTION
`AVAudioSession` has a [mode parameter](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616614-setmode?language=objc) that is designed to work in tandem with a category to determine the OS-level mixing behavior across multiple app's sessions.

This PR adds support for setting the mode parameter in a manner similar to category. It includes type annotations and documentation.

This PR also adds support for invoking `setActive` on the `AVAudioSession`, which is something that has been lost in the deprecation of the `enable` and `enableInSilenceMode` methods. `setActive` is an important mechanism for signalling the interruptibility of the current app. I considered just calling `setActive: YES` within `setCategory`, but in light of the addition of `setMode`, it makes more sense to have this as an independent method.

These aren't useful for 95% of apps (the simple use cases), but if you want to build an iOS app that is resilient to phone calls and other interruptions, these are important.