### PR TITLE
feat(native): allow passing `preserveEncoding` option that doesn't strip URI encoded components from URLs

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -153,7 +153,11 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
   AVAudioPlayer* player;
 
   if ([fileName hasPrefix:@"http"]) {
-    fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+    Boolean preserveEncoding = !![options valueForKey:@"preserveEncoding"];
+      fileNameUrl = preserveEncoding
+      ? [NSURL URLWithString:fileName]
+      : [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+
     NSData* data = [NSData dataWithContentsOfURL:fileNameUrl];
     player = [[AVAudioPlayer alloc] initWithData:data error:&error];
   }


### PR DESCRIPTION
Allow passing a `preserveEncoding` option as part of the `options` taken by the Sound constructor to
allow bypassing the behavior of stripping URL-encoded components from the filename (URL). Some URLs
need this (like for example, Firebase Storage URLs) and without this option we're unable to load the
file and would potentially have to resort to downloading first. Both the initial issue and the fix
have been tested against the demo project.

Example usage:

```javascript
const sound = new Sound(this.props.uri, '', (error) => {
  if (error) {
    console.error('Error loading audio file', error);
  }
}, {
  preserveEncoding: true,
});
```

I recommend a better error message from the audio file fails to load (i.e doesn't exist), as the
obscure error code -10875 could be more often than not a "File not found" error, as part of a
separate issue.