### PR TITLE
Fix breaking changes in React Native 0.47

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundPackage.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundPackage.java
@@ -19,7 +19,8 @@ public class RNSoundPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated RN 0.47
+  // @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
- 'createJSModules' was removed in RN 0.47, so the original code has
  nothing to override and building fails. Remove the override, but not the
  function, to maintain BC.
- See https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8
- Fixes #238 