### PR TITLE
Add possibility to load Android asset files using asset:/ filename prefix

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -115,6 +115,19 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       return mediaPlayer;
     }
 
+    if (fileName.startsWith("asset:/")){
+        try {
+            AssetFileDescriptor descriptor = this.context.getAssets().openFd(fileName.replace("asset:/", ""));
+            MediaPlayer mediaPlayer = new MediaPlayer();
+            mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
+            descriptor.close();
+            return mediaPlayer;
+        } catch(IOException e) {
+            Log.e("RNSoundModule", "Exception", e);
+            return null;
+        }
+    }
+
     File file = new File(fileName);
     if (file.exists()) {
       Uri uri = Uri.fromFile(file);

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -1,5 +1,6 @@
 package com.zmxv.RNSound;
 
+import android.content.res.AssetFileDescriptor;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.media.MediaPlayer.OnErrorListener;

--- a/sound.js
+++ b/sound.js
@@ -7,7 +7,7 @@ var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSourc
 var nextKey = 0;
 
 function isRelativePath(path) {
-  return !/^(\/|http(s?))/.test(path);
+  return !/^(\/|http(s?)|asset)/.test(path);
 }
 
 function Sound(filename, basePath, onError, options) {


### PR DESCRIPTION
This feature is in-line with RN `<Image>` support https://facebook.github.io/react-native/docs/images.html#images-from-hybrid-app-s-resources