### PR TITLE
Add implementation of the reset method for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Playback completion callback | ✓ | ✓ | ✓
 Pause | ✓ | ✓ | ✓
 Resume | ✓ | ✓ | ✓
 Stop | ✓ | ✓ | ✓
+Reset |  | ✓ | 
 Release resource | ✓ | ✓ | ✓
 Get duration | ✓ | ✓ | ✓
 Get number of channels | ✓ |   |
@@ -151,6 +152,9 @@ whoosh.play((success) => {
     console.log('successfully finished playing');
   } else {
     console.log('playback failed due to audio decoding errors');
+    // reset the player to its uninitialized state (android only)
+    // this is the only option to recover after an error occured and use the player again
+    whoosh.reset();
   }
 });
 
@@ -215,6 +219,9 @@ Pause the sound.
 `callback` {?function()} Optional callback function that gets called when the sound has been stopped.
 
 Stop playback and set the seek position to 0.
+
+### `reset()`
+Reset the audio player to its uninitialized state (Android only)
 
 ### `release()`
 Release the audio player resource associated with the instance.

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -184,6 +184,14 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void reset(final Integer key) {
+    MediaPlayer player = this.playerPool.get(key);
+    if (player != null) {
+      player.reset();
+    }
+  }
+
+  @ReactMethod
   public void release(final Integer key) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,17 +17,17 @@ export default class Sound {
    * Sets AVAudioSession as active, which is recommended on iOS to achieve seamless background playback.
    * Use this method to deactivate the AVAudioSession when playback is finished in order for other apps
    * to regain access to the audio stack.
-   * 
+   *
    * @param category AVAudioSession category
    * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
    */
   static setActive(active: boolean): void
 
   /**
-   * Sets AVAudioSession category, which allows playing sound in background, 
-   * stop sound playback when phone is locked, etc. 
+   * Sets AVAudioSession category, which allows playing sound in background,
+   * stop sound playback when phone is locked, etc.
    * Parameter options: "Ambient", "SoloAmbient", "Playback", "Record", "PlayAndRecord", "AudioProcessing", "MultiRoute".
-   * 
+   *
    * @param category AVAudioSession category
    * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
    */
@@ -36,7 +36,7 @@ export default class Sound {
   /**
    * Sets AVAudioSession mode, which works in conjunction with the category to determine audio mixing behavior.
    * Parameter options: "Default", "VoiceChat", "VideoChat", "GameChat", "VideoRecording", "Measurement", "MoviePlayback", "SpokenAudio".
-   * 
+   *
    * @param mode AVAudioSession mode
    * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
    */
@@ -73,12 +73,17 @@ export default class Sound {
   stop(cb?: () => void): void
 
   /**
+   * Reset the audio player to its uninitialized state (android only)
+   */
+  reset(): void
+
+  /**
    * Release the audio player resource associated with the instance.
    */
   release(): void
 
   /**
-   * Return the number of channels 
+   * Return the number of channels
    * (1 for mono and 2 for stereo sound), or -1 before the sound gets loaded.
    */
   getNumberOfChannels(): number
@@ -108,9 +113,9 @@ export default class Sound {
   setPan(value: number): void
 
   /**
-   * Return the loop count of the audio player. 
-   * The default is 0 which means to play the sound once. 
-   * A positive number specifies the number of times to return to the start and play again. 
+   * Return the loop count of the audio player.
+   * The default is 0 which means to play the sound once.
+   * A positive number specifies the number of times to return to the start and play again.
    * A negative number indicates an indefinite loop.
    */
   getNumberOfLoops(): number
@@ -123,33 +128,33 @@ export default class Sound {
 
   /**
    * Callback will receive the current playback position in seconds and whether the sound is being played.
-   * @param cb 
+   * @param cb
    */
   getCurrentTime(cb?: (seconds: number, isPlaying: boolean) => void): void
 
   /**
    * Seek to a particular playback point in seconds.
-   * @param value 
+   * @param value
    */
   setCurrentTime(value: number): void
 
   /**
    * Speed of the audio playback (iOS Only).
-   * @param value 
+   * @param value
    */
   setSpeed(value: number): void
 
   /**
    * Whether to enable playback in silence mode (iOS only)
    * @deprecated - Use the static method Sound.setCategory('Playback') instead which has the same effect.
-   * @param enabled 
+   * @param enabled
    */
   enableInSilenceMode(enabled: boolean): void
 
   /**
    * Sets AVAudioSession category
    * @deprecated
-   * @param value 
+   * @param value
    */
   setCategory(value: AVAudioSessionCategory): void
 

--- a/sound.js
+++ b/sound.js
@@ -74,6 +74,13 @@ Sound.prototype.stop = function(callback) {
   return this;
 };
 
+Sound.prototype.reset = function() {
+  if (this._loaded && IsAndroid) {
+    RNSound.reset(this._key);
+  }
+  return this;
+};
+
 Sound.prototype.release = function() {
   if (this._loaded) {
     RNSound.release(this._key);


### PR DESCRIPTION
The reset-method sets the MediaPlayer to its uninitialized state. After calling this method, you will have to initialize it again by setting the data source and calling prepare().
It's the only way to reuse a MediaPlayer after an error ocurred and the MediaPlayer is in the Error state.
See also: https://developer.android.com/reference/android/media/MediaPlayer.html#reset() and https://developer.android.com/reference/android/media/MediaPlayer.html#StateDiagram

Fixes #247