### PR TITLE
Add props parameter to player prepare callback

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -43,7 +43,7 @@ function Sound(filename, basePath, onError, options) {
     if (error === null) {
       this._loaded = true;
     }
-    onError && onError(error);
+    onError && onError(error, props);
   });
 }
 


### PR DESCRIPTION
According to the documentation the onError callback has a props parameter where the duration and number of channels are returned. This was implemented in the Android & iOS code, but not in the JavaScript. This commit fixes this.

Fixes #250