### PR TITLE
Set loaded flag to false after releasing player

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Return the loop count of the audio player. The default is `0` which means to pla
 `value` {number} Seek to a particular playback point in seconds.
 
 ### `setSpeed(value)`
-`value` {number} Speed of the audio playback (iOS Only).
+`value` {number} Speed of the audio playback.
 
 ### `setSpeakerphoneOn(value)`
 `speaker` {boolean} Sets the speakerphone on or off (Android only).

--- a/sound.js
+++ b/sound.js
@@ -84,6 +84,7 @@ Sound.prototype.reset = function() {
 Sound.prototype.release = function() {
   if (this._loaded) {
     RNSound.release(this._key);
+    this._loaded = false;
   }
   return this;
 };


### PR DESCRIPTION
When the player has been released the file isn't loaded anymore, so
isLoaded() must return false.

Fixes #231