### PR TITLE
Fix callback

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -14,7 +14,6 @@ function Sound(filename, basePath, onError, options) {
   var asset = resolveAssetSource(filename);
   if (asset) {
     this._filename = asset.uri;
-    onError = basePath;
   } else {
     this._filename = basePath ? basePath + '/' + filename : filename;
 


### PR DESCRIPTION
Not sure why this line was there, but with it, I get a "onError is not a function" exception if I provide a callback:

```const sound = new Sound(soundFile, Sound.MAIN_BUNDLE, (error) => {
      if (error) {
        console.log('Failed to load sound', error);
        reject(error);
      }
      resolve(sound);
    })```