### PR TITLE
Android set category

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ First you'll need to add audio files to your project.
 // Import the react-native-sound module
 var Sound = require('react-native-sound');
 
-// Enable playback in silence mode (iOS only)
+// Enable playback in silence mode
 Sound.setCategory('Playback');
 
 // Load the sound file 'whoosh.mp3' from the app bundle

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -28,10 +28,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   Map<Integer, MediaPlayer> playerPool = new HashMap<>();
   ReactApplicationContext context;
   final static Object NULL = null;
+  String category;
 
   public RNSoundModule(ReactApplicationContext context) {
     super(context);
     this.context = context;
+    this.category = null;
   }
 
   @Override
@@ -50,6 +52,27 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     }
 
     final RNSoundModule module = this;
+
+    if (module.category != null) {
+      Integer category = null;
+      switch (module.category) {
+        case "Playback":
+          category = AudioManager.STREAM_MUSIC;
+          break;
+        case "Ambient":
+          category = AudioManager.STREAM_NOTIFICATION;
+          break;
+        case "System":
+          category = AudioManager.STREAM_SYSTEM;
+          break;
+        default:
+          Log.e("RNSoundModule", String.format("Unrecognised category %s", module.category));
+          break;
+      }
+      if (category != null) {
+        player.setAudioStreamType(category);
+      }
+    }
 
     player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       boolean callbackWasCalled = false;
@@ -102,11 +125,20 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
 
   protected MediaPlayer createMediaPlayer(final String fileName) {
     int res = this.context.getResources().getIdentifier(fileName, "raw", this.context.getPackageName());
+    MediaPlayer mediaPlayer = new MediaPlayer();
     if (res != 0) {
-      return MediaPlayer.create(this.context, res);
+      try {
+        AssetFileDescriptor afd = context.getResources().openRawResourceFd(res);
+        mediaPlayer.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+        afd.close();
+      } catch (IOException e) {
+        Log.e("RNSoundModule", "Exception", e);
+        return null;
+      }
+      return mediaPlayer;
     }
-    if(fileName.startsWith("http://") || fileName.startsWith("https://")) {
-      MediaPlayer mediaPlayer = new MediaPlayer();
+
+    if (fileName.startsWith("http://") || fileName.startsWith("https://")) {
       mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
       Log.i("RNSoundModule", fileName);
       try {
@@ -121,7 +153,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     if (fileName.startsWith("asset:/")){
         try {
             AssetFileDescriptor descriptor = this.context.getAssets().openFd(fileName.replace("asset:/", ""));
-            MediaPlayer mediaPlayer = new MediaPlayer();
             mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
             descriptor.close();
             return mediaPlayer;
@@ -290,6 +321,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
       audioManager.setSpeakerphoneOn(speaker);
     }
+  }
+
+  @ReactMethod
+  public void setCategory(final String category, final Boolean mixWithOthers) {
+    this.category = category;
   }
 
   @ReactMethod

--- a/sound.js
+++ b/sound.js
@@ -209,7 +209,7 @@ Sound.setActive = function(value) {
 };
 
 Sound.setCategory = function(value, mixWithOthers = false) {
-  if (!IsAndroid && !IsWindows) {
+  if (!IsWindows) {
     RNSound.setCategory(value, mixWithOthers);
   }
 };


### PR DESCRIPTION
Allow setting of audio stream type on android. I've mirrored the api for iOS but I'm not sure if that is a good idea since the values aren't the same. What do you think?

N.B. I also had to refactor the media player creation slightly since `MediaPlayer.create` calls `prepare` after which you can't set the stream type. Since `.prepareAsync` is called at the end of the `createMediaPlayer` function I don't think removing `.create` calls should change anything however I haven't tested it fully.