### PR TITLE
Correct import priority for React/RCTBridgeModule.h (for RN 0.48+)

### DIFF
--- a/RNSound/RNSound.h
+++ b/RNSound/RNSound.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-    #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
     #import <React/RCTBridgeModule.h>
+#else
+    #import "RCTBridgeModule.h"
 #endif
 
 #import <AVFoundation/AVFoundation.h>


### PR DESCRIPTION
This address the redefinition of RCTMethodInfo in RN 0.48+.