### PR TITLE
Fix premature collection of MediaPlayer on Android

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -48,6 +48,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       e.putString("message", "resource not found");
       return;
     }
+    this.playerPool.put(key, player);
 
     final RNSoundModule module = this;
 
@@ -59,7 +60,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         if (callbackWasCalled) return;
         callbackWasCalled = true;
 
-        module.playerPool.put(key, mp);
         WritableMap props = Arguments.createMap();
         props.putDouble("duration", mp.getDuration() * .001);
         try {


### PR DESCRIPTION
If the `MediaPlayer` takes a while to prepare, it's possible that a GC will cause the `MediaPlayer` to be collected between the time that `prepareAsync` is called and the time that the `OnPreparedListener` is invoked.

By moving the assignment of the `playerPool` reference to immediately following the instantiation of the MediaPlayer, we eliminate the risk of premature collection.

(It's worth noting that if the `MediaPlayer` is collected before preparation completes, the `Sound` constructor callback will never be invoked.)