### PR TITLE
Minor fix on declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ type AVAudioSessionCategory = 'Ambient' | 'SoloAmbient' | 'Playback' | 'Record' 
 
 type AVAudioSessionMode = 'Default' | 'VoiceChat' | 'VideoChat' | 'GameChat' | 'VideoRecording' | 'Measurement' | 'MoviePlayback' | 'SpokenAudio'
 
-export default class Sound {
+declare class Sound {
   static MAIN_BUNDLE: string
   static DOCUMENT: string
   static LIBRARY: string
@@ -169,3 +169,5 @@ export default class Sound {
    */
   setSpeakerphoneOn(value: boolean): void
 }
+
+export = Sound;


### PR DESCRIPTION
The typescript declaration file was not exporting the Sound class properly for a lib that uses the CommonJS exporting mechanism. This commit fixes that issue.

Import from typescript project as follows:

import Sound = require("react-native-sound")
