### PR TITLE
Fix: Illegal callback invocation

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -157,7 +157,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
         if (callbackWasCalled) return true;
         callbackWasCalled = true;
-        callback.invoke(false);
+        try {
+          callback.invoke(true);
+        } catch (Exception e) {
+          //Catches the exception: java.lang.RuntimeException·Illegal callback invocation from native module
+        }
         return true;
       }
     });


### PR DESCRIPTION
To solve the problem of illegal callback invocation thrown in RNSoundModule by putting the block "callback.invoke" in a try catch