### PR TITLE
[Android] mixWithOthers implementation via AudioManager requestAudioFocus

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -24,11 +24,15 @@ import java.io.IOException;
 
 import android.util.Log;
 
-public class RNSoundModule extends ReactContextBaseJavaModule {
+public class RNSoundModule extends ReactContextBaseJavaModule implements AudioManager.OnAudioFocusChangeListener {
   Map<Integer, MediaPlayer> playerPool = new HashMap<>();
   ReactApplicationContext context;
   final static Object NULL = null;
   String category;
+  Boolean mixWithOthers = true;
+
+  Integer focusedPlayerKey;
+  Boolean wasPlayingBeforeFocusChange;
 
   public RNSoundModule(ReactApplicationContext context) {
     super(context);
@@ -175,12 +179,23 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   public void play(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
-      callback.invoke(false);
+      if (callback != null) {
+          callback.invoke(false);
+      }
       return;
     }
     if (player.isPlaying()) {
       return;
     }
+
+    // Request audio focus in Android system
+    if (!this.mixWithOthers) {
+      AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+      audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+
+      this.focusedPlayerKey = key;
+    }
+
     player.setOnCompletionListener(new OnCompletionListener() {
       boolean callbackWasCalled = false;
 
@@ -217,7 +232,10 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     if (player != null && player.isPlaying()) {
       player.pause();
     }
-    callback.invoke();
+    
+    if (callback != null) {
+      callback.invoke();
+    }
   }
 
   @ReactMethod
@@ -227,6 +245,13 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       player.pause();
       player.seekTo(0);
     }
+    
+    // Release audio focus in Android system
+    if (!this.mixWithOthers) {
+      AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+      audioManager.abandonAudioFocus(this);
+    }
+
     callback.invoke();
   }
 
@@ -326,6 +351,29 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void setCategory(final String category, final Boolean mixWithOthers) {
     this.category = category;
+    this.mixWithOthers = mixWithOthers;
+  }
+
+  @Override
+  public void onAudioFocusChange(int focusChange) {
+    if (!this.mixWithOthers) {
+      MediaPlayer player = this.playerPool.get(this.focusedPlayerKey);
+      
+      if (player != null) {
+        if (focusChange <= 0) {
+            this.wasPlayingBeforeFocusChange = player.isPlaying();
+
+            if (this.wasPlayingBeforeFocusChange) {
+              this.pause(this.focusedPlayerKey, null);
+            }
+        } else {
+            if (this.wasPlayingBeforeFocusChange) {
+              this.play(this.focusedPlayerKey, null);
+              this.wasPlayingBeforeFocusChange = false;
+            }
+        }
+      }
+    }
   }
 
   @ReactMethod

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -247,7 +247,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     }
     
     // Release audio focus in Android system
-    if (!this.mixWithOthers) {
+    if (!this.mixWithOthers && key = this.focusedPlayerKey) {
       AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
       audioManager.abandonAudioFocus(this);
     }
@@ -269,6 +269,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     if (player != null) {
       player.release();
       this.playerPool.remove(key);
+
+      // Release audio focus in Android system
+      if (!this.mixWithOthers && key = this.focusedPlayerKey) {
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        audioManager.abandonAudioFocus(this);
+      }
     }
   }
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundPackage.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundPackage.java
@@ -20,7 +20,6 @@ public class RNSoundPackage implements ReactPackage {
   }
 
   // Deprecated RN 0.47
-  // @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/sound.js
+++ b/sound.js
@@ -47,11 +47,11 @@ function Sound(filename, basePath, onError, options) {
   });
 }
 
-Sound.prototype.isLoaded = function() {
+Sound.prototype.isLoaded = function () {
   return this._loaded;
 };
 
-Sound.prototype.play = function(onEnd) {
+Sound.prototype.play = function (onEnd) {
   if (this._loaded) {
     RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
   } else {
@@ -60,28 +60,28 @@ Sound.prototype.play = function(onEnd) {
   return this;
 };
 
-Sound.prototype.pause = function(callback) {
+Sound.prototype.pause = function (callback) {
   if (this._loaded) {
     RNSound.pause(this._key, () => { callback && callback() });
   }
   return this;
 };
 
-Sound.prototype.stop = function(callback) {
+Sound.prototype.stop = function (callback) {
   if (this._loaded) {
     RNSound.stop(this._key, () => { callback && callback() });
   }
   return this;
 };
 
-Sound.prototype.reset = function() {
+Sound.prototype.reset = function () {
   if (this._loaded && IsAndroid) {
     RNSound.reset(this._key);
   }
   return this;
 };
 
-Sound.prototype.release = function() {
+Sound.prototype.release = function () {
   if (this._loaded) {
     RNSound.release(this._key);
     this._loaded = false;
@@ -89,19 +89,19 @@ Sound.prototype.release = function() {
   return this;
 };
 
-Sound.prototype.getDuration = function() {
+Sound.prototype.getDuration = function () {
   return this._duration;
 };
 
-Sound.prototype.getNumberOfChannels = function() {
+Sound.prototype.getNumberOfChannels = function () {
   return this._numberOfChannels;
 };
 
-Sound.prototype.getVolume = function() {
+Sound.prototype.getVolume = function () {
   return this._volume;
 };
 
-Sound.prototype.setVolume = function(value) {
+Sound.prototype.setVolume = function (value) {
   this._volume = value;
   if (this._loaded) {
     if (IsAndroid || IsWindows) {
@@ -113,36 +113,36 @@ Sound.prototype.setVolume = function(value) {
   return this;
 };
 
-Sound.prototype.getSystemVolume = function(callback) {
-  if(IsAndroid) {
+Sound.prototype.getSystemVolume = function (callback) {
+  if (IsAndroid) {
     RNSound.getSystemVolume(callback);
   }
   return this;
 };
 
-Sound.prototype.setSystemVolume = function(value) {
+Sound.prototype.setSystemVolume = function (value) {
   if (IsAndroid) {
     RNSound.setSystemVolume(value);
   }
   return this;
 };
 
-Sound.prototype.getPan = function() {
+Sound.prototype.getPan = function () {
   return this._pan;
 };
 
-Sound.prototype.setPan = function(value) {
+Sound.prototype.setPan = function (value) {
   if (this._loaded) {
     RNSound.setPan(this._key, this._pan = value);
   }
   return this;
 };
 
-Sound.prototype.getNumberOfLoops = function() {
+Sound.prototype.getNumberOfLoops = function () {
   return this._numberOfLoops;
 };
 
-Sound.prototype.setNumberOfLoops = function(value) {
+Sound.prototype.setNumberOfLoops = function (value) {
   this._numberOfLoops = value;
   if (this._loaded) {
     if (IsAndroid || IsWindows) {
@@ -154,7 +154,7 @@ Sound.prototype.setNumberOfLoops = function(value) {
   return this;
 };
 
-Sound.prototype.setSpeed = function(value) {
+Sound.prototype.setSpeed = function (value) {
   this._setSpeed = value;
   if (this._loaded) {
     if (!IsWindows) {
@@ -164,13 +164,13 @@ Sound.prototype.setSpeed = function(value) {
   return this;
 };
 
-Sound.prototype.getCurrentTime = function(callback) {
+Sound.prototype.getCurrentTime = function (callback) {
   if (this._loaded) {
     RNSound.getCurrentTime(this._key, callback);
   }
 };
 
-Sound.prototype.setCurrentTime = function(value) {
+Sound.prototype.setCurrentTime = function (value) {
   if (this._loaded) {
     RNSound.setCurrentTime(this._key, value);
   }
@@ -178,7 +178,7 @@ Sound.prototype.setCurrentTime = function(value) {
 };
 
 // android only
-Sound.prototype.setSpeakerphoneOn = function(value) {
+Sound.prototype.setSpeakerphoneOn = function (value) {
   if (IsAndroid) {
     RNSound.setSpeakerphoneOn(this._key, value);
   }
@@ -188,33 +188,33 @@ Sound.prototype.setSpeakerphoneOn = function(value) {
 
 // This is deprecated.  Call the static one instead.
 
-Sound.prototype.setCategory = function(value) {
+Sound.prototype.setCategory = function (value) {
   Sound.setCategory(value, false);
 }
 
-Sound.enable = function(enabled) {
+Sound.enable = function (enabled) {
   RNSound.enable(enabled);
 };
 
-Sound.enableInSilenceMode = function(enabled) {
+Sound.enableInSilenceMode = function (enabled) {
   if (!IsAndroid && !IsWindows) {
     RNSound.enableInSilenceMode(enabled);
   }
 };
 
-Sound.setActive = function(value) {
+Sound.setActive = function (value) {
   if (!IsAndroid && !IsWindows) {
     RNSound.setActive(value);
   }
 };
 
-Sound.setCategory = function(value, mixWithOthers = false) {
+Sound.setCategory = function (value, mixWithOthers = false) {
   if (!IsWindows) {
     RNSound.setCategory(value, mixWithOthers);
   }
 };
 
-Sound.setMode = function(value) {
+Sound.setMode = function (value) {
   if (!IsAndroid && !IsWindows) {
     RNSound.setMode(value);
   }
@@ -225,4 +225,4 @@ Sound.DOCUMENT = RNSound.NSDocumentDirectory;
 Sound.LIBRARY = RNSound.NSLibraryDirectory;
 Sound.CACHES = RNSound.NSCachesDirectory;
 
-module.exports = Sound;
+export default Sound;


### PR DESCRIPTION
**Scenario**
You sent mixWithOthers to false in your app. The user plays an audio, e. g. a music, and uses Google Maps at the same time.

**Expected**
The music is playing. As soon as an message comes through Google Maps, the music stops and starts again after the message.

**Actual**
Music and the message through Google Maps overlap, as long as the other app does not claim to be the exclusive audio focus.

**Solution**
If mixWithOthers is set to false, AudioFocus is set to false via AudioManager. The focus is only valid for the last player (some exclusive audio scenarios). As soon as the player is stopped or released, the AudioFocus will be removed. 