### PR TITLE
[Android] mixWithOthers implementation via AudioManager requestAudioFocus

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -24,11 +24,15 @@ import java.io.IOException;
 
 import android.util.Log;
 
-public class RNSoundModule extends ReactContextBaseJavaModule {
+public class RNSoundModule extends ReactContextBaseJavaModule implements AudioManager.OnAudioFocusChangeListener {
   Map<Integer, MediaPlayer> playerPool = new HashMap<>();
   ReactApplicationContext context;
   final static Object NULL = null;
   String category;
+  Boolean mixWithOthers = true;
+
+  Integer focusedPlayerKey;
+  Boolean wasPlayingBeforeFocusChange;
 
   public RNSoundModule(ReactApplicationContext context) {
     super(context);
@@ -175,12 +179,24 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   public void play(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
-      callback.invoke(false);
+      if (callback != null) {
+          callback.invoke(false);
+      }
       return;
     }
     if (player.isPlaying()) {
       return;
     }
+
+    // Request audio focus in Android system
+    if (!this.mixWithOthers) {
+      AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+      
+      audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+
+      this.focusedPlayerKey = key;
+    }
+
     player.setOnCompletionListener(new OnCompletionListener() {
       boolean callbackWasCalled = false;
 
@@ -217,7 +233,10 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     if (player != null && player.isPlaying()) {
       player.pause();
     }
-    callback.invoke();
+    
+    if (callback != null) {
+      callback.invoke();
+    }
   }
 
   @ReactMethod
@@ -227,6 +246,13 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       player.pause();
       player.seekTo(0);
     }
+    
+    // Release audio focus in Android system
+    if (!this.mixWithOthers && key == this.focusedPlayerKey) {
+      AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+      audioManager.abandonAudioFocus(this);
+    }
+
     callback.invoke();
   }
 
@@ -244,6 +270,12 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     if (player != null) {
       player.release();
       this.playerPool.remove(key);
+
+      // Release audio focus in Android system
+      if (!this.mixWithOthers && key == this.focusedPlayerKey) {
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        audioManager.abandonAudioFocus(this);
+      }
     }
   }
 
@@ -326,6 +358,29 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void setCategory(final String category, final Boolean mixWithOthers) {
     this.category = category;
+    this.mixWithOthers = mixWithOthers;
+  }
+
+  @Override
+  public void onAudioFocusChange(int focusChange) {
+    if (!this.mixWithOthers) {
+      MediaPlayer player = this.playerPool.get(this.focusedPlayerKey);
+      
+      if (player != null) {
+        if (focusChange <= 0) {
+            this.wasPlayingBeforeFocusChange = player.isPlaying();
+
+            if (this.wasPlayingBeforeFocusChange) {
+              this.pause(this.focusedPlayerKey, null);
+            }
+        } else {
+            if (this.wasPlayingBeforeFocusChange) {
+              this.play(this.focusedPlayerKey, null);
+              this.wasPlayingBeforeFocusChange = false;
+            }
+        }
+      }
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
**Scenario**
You sent mixWithOthers to false in your app. The user plays an audio, e. g. a music, and uses Google Maps at the same time.

**Expected**
The music is playing. As soon as an message comes through Google Maps, the music stops and starts again after the message.

**Actual**
Music and the message through Google Maps overlap, as long as the other app does not claim to be the exclusive audio focus.

**Solution**
If mixWithOthers is set to false, AudioFocus is set to false via AudioManager. The focus is only valid for the last player (some exclusive audio scenarios). As soon as the player is stopped or released, the AudioFocus will be removed. 