### PR TITLE
Fix Android every Sound instance can be released

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -11,6 +11,7 @@ import android.media.AudioManager;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
@@ -30,7 +31,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   final static Object NULL = null;
   String category;
   Boolean mixWithOthers = true;
-  Integer focusedPlayerKey;
+  Double focusedPlayerKey;
   Boolean wasPlayingBeforeFocusChange = false;
 
   public RNSoundModule(ReactApplicationContext context) {
@@ -39,12 +40,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     this.category = null;
   }
 
-  private void setOnPlay(boolean isPlaying, final Integer playerKey) {
+  private void setOnPlay(boolean isPlaying, final Double playerKey) {
     final ReactContext reactContext = this.context;
     WritableMap params = Arguments.createMap();
     params.putBoolean("isPlaying", isPlaying);
-    params.putInt("playerKey", playerKey);
-    sendEvent(reactContext, "onPlayChange", params);
+    params.putDouble("playerKey", playerKey);
   }
 
   @Override
@@ -61,7 +61,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
       e.putString("message", "resource not found");
       return;
     }
-    this.playerPool.put(key, player);
 
     final RNSoundModule module = this;
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -82,7 +82,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         if (callbackWasCalled) return;
         callbackWasCalled = true;
 
-        module.playerPool.put(key, mp);
         WritableMap props = Arguments.createMap();
         props.putDouble("duration", mp.getDuration() * .001);
         try {
@@ -114,6 +113,8 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         return true;
       }
     });
+
+    module.playerPool.put(key, player);
 
     try {
       player.prepareAsync();

--- a/sound.js
+++ b/sound.js
@@ -82,10 +82,8 @@ Sound.prototype.reset = function() {
 };
 
 Sound.prototype.release = function() {
-  if (this._loaded) {
-    RNSound.release(this._key);
-    this._loaded = false;
-  }
+  RNSound.release(this._key);
+  this._loaded = false;
   return this;
 };
 


### PR DESCRIPTION
In some Android devices only the first time can loaded success, then new Sound not invoke loaded callback forever. I check this code, the issue is about sound release. So I change it, make every Sound instance can be released. It works for me.