### PR TITLE
Add an option to load file synchronously on Android

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -121,9 +121,10 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       } else {
         player.prepareAsync();
       }
-    } catch (IllegalStateException ignored) {
+    } catch (Exception ignored) {
       // When loading files from a file, we useMediaPlayer.create, which actually
       // prepares the audio for us already. So we catch and ignore this error
+      Log.e("RNSoundModule", "Exception", ignored);
     }
   }
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -116,7 +116,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     });
 
     try {
-      player.prepareAsync();
+      if(options.hasKey("loadSync") && options.getBoolean("loadSync")) {
+        player.prepare();
+      } else {
+        player.prepareAsync();
+      }
     } catch (IllegalStateException ignored) {
       // When loading files from a file, we useMediaPlayer.create, which actually
       // prepares the audio for us already. So we catch and ignore this error


### PR DESCRIPTION
On android, the sound file may take some time to load in which case if a client tries to play the sound right way, the sound wouldn't be played. This is because the sound is loaded asynchronously by default. Android documentation recommends doing so for streams but also states that it is okay to load the sound file synchronously if the files are local. Added an option that a user can use to specify if they want to load the sound file synchronously or asynchronously.

This change only applies to Android. I will also add a commit for documentation.