### PR TITLE
Use a hash function to compute key based on file name.

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -4,10 +4,19 @@ var RNSound = require('react-native').NativeModules.RNSound;
 var IsAndroid = RNSound.IsAndroid;
 var IsWindows = RNSound.IsWindows;
 var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSource");
-var nextKey = 0;
 
 function isRelativePath(path) {
   return !/^(\/|http(s?)|asset)/.test(path);
+}
+
+// Hash function to compute key from the filename
+function djb2Code(str) {
+  var hash = 5381, i, char;
+  for (i = 0; i < str.length; i++) {
+      char = str.charCodeAt(i);
+      hash = ((hash << 5) + hash) + char; /* hash * 33 + c */
+  }
+  return hash;
 }
 
 function Sound(filename, basePath, onError, options) {
@@ -24,7 +33,7 @@ function Sound(filename, basePath, onError, options) {
   }
 
   this._loaded = false;
-  this._key = nextKey++;
+  this._key = djb2Code(filename);
   this._duration = -1;
   this._numberOfChannels = -1;
   this._volume = 1;


### PR DESCRIPTION
Sometimes, I have observed problems with playing sounds due to the incremental key due to which the native code has a different key as compared to the JS code. I think ideally, we should just the `fileName` as the key but that would require many changes in the native code and I just used a hash function to compute an integer code for the file name and use that as the key.