### PR TITLE
Works to play local sound files through JS require

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -191,7 +191,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
     player = [[AVAudioPlayer alloc] initWithContentsOfURL:fileNameUrl error:&error];
   }
   else {
-    fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
+	fileNameUrl = [[NSURL alloc] initWithString:fileName];
     player = [[AVAudioPlayer alloc]
               initWithContentsOfURL:fileNameUrl
               error:&error];


### PR DESCRIPTION
Received error `ENSOSSTATUSERRORDOMAIN`

Similar to this:
https://github.com/zmxv/react-native-sound/issues/229
but when playing local files through JS require('asset/name.mp3')

The stringByRemovingPercentEncoding broke the file path