### PR TITLE
added requiresMainQueueSetup

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -294,4 +294,9 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
   }
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
This removes the warning:

Module RNSound requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.