### PR TITLE
Remove URL unescaping for web URL sources.

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -182,7 +182,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
   AVAudioPlayer* player;
 
   if ([fileName hasPrefix:@"http"]) {
-    fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+    fileNameUrl = [NSURL URLWithString:fileName];
     NSData* data = [NSData dataWithContentsOfURL:fileNameUrl];
     player = [[AVAudioPlayer alloc] initWithData:data error:&error];
   }


### PR DESCRIPTION
When providing a web URL for the sound asset, if that URL contains
percent escape sequences, an NSOSStatusErrorDomain error is thrown.
This is because stringByRemovingPercentEncoding was being called
on the URL before being sent to URLWithString. As per documentation:

> This method expects URLString to contain only characters that are
> allowed in a properly formed URL. All other characters must be
> properly percent escaped. Any percent-escaped characters are
> interpreted using UTF-8 encoding.

This commit removes the call to stringByRemovingPercentEncoding,
allowing escaped characters to pass through as required.