### PR TITLE
Implements isPlaying() for android and ios && fix not to autoplay on setSpeed for android + PR #211

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Get/set volume | ✓ | ✓ | ✓
 Get/set pan | ✓ |   |
 Get/set loops | ✓ | ✓ | ✓
 Get/set current time | ✓ | ✓ | ✓
-Set speed | ✓ |   |
+Set speed | ✓ | ✓ |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feature | iOS | Android | Windows
 ---|---|---|---
 Load sound from the app bundle | ✓ | ✓ | ✓  
 Load sound from other directories | ✓ | ✓ | ✓
-Load sound from the network | ✓ |   |
+Load sound from the network | ✓ | ✓ |
 Play sound | ✓ | ✓ | ✓
 Playback completion callback | ✓ | ✓ | ✓
 Pause | ✓ | ✓ | ✓

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # react-native-sound
 
-React Native module for playing sound clips on iOS and Android.
+React Native module for playing sound clips on iOS, Android, and Windows.
 
 ## Feature matrix
 
 Feature | iOS | Android | Windows
----|---|---|---|---
+---|---|---|---
 Load sound from the app bundle | ✓ | ✓ | ✓  
 Load sound from other directories | ✓ | ✓ | ✓
 Load sound from the network | ✓ |   |

--- a/README.md
+++ b/README.md
@@ -271,6 +271,6 @@ To play sound in the background, make sure to add the following to the `Info.pli
 - To minimize playback delay, you may want to preload a sound file without calling `play()` (e.g. `var s = new Sound(...);`) during app initialization. This also helps avoid a race condition where `play()` may be called before loading of the sound is complete, which results in no sound but no error because loading is still being processed.
 - You can play multiple sound files at the same time. Under the hood, this module uses `AVAudioSessionCategoryAmbient` to mix sounds on iOS.
 - You may reuse a `Sound` instance for multiple playbacks.
-- On iOS, the module wraps `AVAudioPlayer` which supports aac, aiff, mp3, wav etc. The full list of supported formats can be found at https://developer.apple.com/library/ios/documentation/AudioVideo/Conceptual/MultimediaPG/UsingAudio/UsingAudio.html
-- On Android, the module wraps `android.media.MediaPlayer`. The full list of supported formats can be found at http://developer.android.com/guide/appendix/media-formats.html
+- On iOS, the module wraps `AVAudioPlayer` that supports aac, aiff, mp3, wav etc. The full list of supported formats can be found at https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/CoreAudioOverview/SupportedAudioFormatsMacOSX/SupportedAudioFormatsMacOSX.html
+- On Android, the module wraps `android.media.MediaPlayer`. The full list of supported formats can be found at https://developer.android.com/guide/topics/media/media-formats.html
 - You may chain non-getter calls, for example, `sound.setVolume(.5).setPan(.5).play()`.

--- a/README.md
+++ b/README.md
@@ -189,12 +189,16 @@ whoosh.release();
 ```
 
 ## API
-### `constructor(filename, basePath, onError)`
+### `constructor(filename, basePath, onError, options)`
 `filename` {string} Either absolute or relative path to the sound file
 
 `basePath` {?string} Optional base path of the file. Omit this or pass `''` if `filename` is an absolute path. Otherwise, you may use one of the predefined directories: `Sound.MAIN_BUNDLE`, `Sound.DOCUMENT`, `Sound.LIBRARY`, `Sound.CACHES`.
 
 `onError` {?function(error, props)} Optional callback function. If the file is successfully loaded, the first parameter `error` is `null`, and `props` contains an object with two properties: `duration` (in seconds) and `numberOfChannels` (`1` for mono and `2` for stereo sound), both of which can also be accessed from the `Sound` instance object. If an initialization error is encountered (e.g. file not found), `error` will be an object containing `code`, `description`, and the stack trace.
+
+`options` {?object} Platform-specific options:
+
+**Windows Only:** `enableSMTCIntegration` {?boolean}. Optional setting for windows to enable or disable SMTC integration (controlling your apps sounds or music via the keyboard, and the built-in media controls on Windows.) This is enabled by default. Set this to false when you don't want users to be able to control your sounds (e.g. sound effects.) See the [Windows.Media.SystemMediaTransportControls documentation](https://docs.microsoft.com/en-us/uwp/api/Windows.Media.SystemMediaTransportControls) for more information.
 
 ### `isLoaded()`
 Return `true` if the sound has been loaded.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ whoosh.getCurrentTime((seconds) => console.log('at ' + seconds));
 whoosh.pause();
 
 // Stop the sound and rewind to the beginning
-whoosh.stop();
+whoosh.stop(() => {
+  // Note: If you want to play a sound after stopping and rewinding it,
+  // it is important to call play() in a callback.
+  whoosh.play();
+});
 
 // Release the audio player resource
 whoosh.release();
@@ -196,13 +200,17 @@ whoosh.release();
 Return `true` if the sound has been loaded.
 
 ### `play(onEnd)`
-`onEnd` {?function(successfully)} Optinoal callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it.
+`onEnd` {?function(successfully)} Optional callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it.
 
-### `pause()`
+### `pause(callback)`
+`callback` {?function()} Optional callback function that gets called when the sound has been paused.
+
 Pause the sound.
 
-### `stop()`
-Stop the playback.
+### `stop(callback)`
+`callback` {?function()} Optional callback function that gets called when the sound has been stopped.
+
+Stop playback and set the seek position to 0.
 
 ### `release()`
 Release the audio player resource associated with the instance.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ Return the loop count of the audio player. The default is `0` which means to pla
 ### `setSpeed(value)`
 `value` {number} Speed of the audio playback (iOS Only).
 
+### `setSpeakerphoneOn(value)`
+`speaker` {boolean} Sets the speakerphone on or off (Android only).
+
+It requires this permission in your AndroidManifest: `<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>`
+
 ### `enableInSilenceMode(enabled)` (deprecated)
 `enabled` {boolean} Whether to enable playback in silence mode (iOS only).
 

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -127,7 +127,7 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
     
   if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
-              initWithData:[[NSData alloc] initWithContentsOfURL:fileNameUrl]
+              initWithContentsOfURL:fileNameUrl
               error:&error];
   }
     

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -44,12 +44,13 @@
 -(void) audioPlayerDidFinishPlaying:(AVAudioPlayer*)player
                        successfully:(BOOL)flag {
   NSNumber* key = [self keyForPlayer:player];
-  if (key != nil) {
-    @synchronized(key) {
-      RCTResponseSenderBlock callback = [self callbackForKey:key];
-      if (callback) {
-        callback(@[@(flag)]);
-      }
+  if (key == nil) return;
+
+  @synchronized(key) {
+    RCTResponseSenderBlock callback = [self callbackForKey:key];
+    if (callback) {
+      callback(@[@(flag)]);
+      [[self callbackPool] removeObjectForKey:key];
     }
   }
 }

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -45,9 +45,11 @@
                        successfully:(BOOL)flag {
   NSNumber* key = [self keyForPlayer:player];
   if (key != nil) {
-    RCTResponseSenderBlock callback = [self callbackForKey:key];
-    if (callback) {
-      callback(@[@(flag)]);
+    @synchronized(key) {
+      RCTResponseSenderBlock callback = [self callbackForKey:key];
+      if (callback) {
+        callback(@[@(flag)]);
+      }
     }
   }
 }

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -151,18 +151,20 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   }
 }
 
-RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)key) {
+RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlock)callback) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player pause];
+    callback(@[]);
   }
 }
 
-RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key) {
+RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlock)callback) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player stop];
     player.currentTime = 0;
+    callback(@[]);
   }
 }
 

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(setCategory:(NSString *)categoryName
     category = AVAudioSessionCategoryRecord;
   } else if ([categoryName isEqual: @"PlayAndRecord"]) {
     category = AVAudioSessionCategoryPlayAndRecord;
-  } 
+  }
   #if TARGET_OS_IOS
   else if ([categoryName isEqual: @"AudioProcessing"]) {
       category = AVAudioSessionCategoryAudioProcessing;
@@ -112,25 +112,27 @@ RCT_EXPORT_METHOD(enableInSilenceMode:(BOOL)enabled) {
   [session setActive: enabled error: nil];
 }
 
-RCT_EXPORT_METHOD(prepare:(NSString*)fileName withKey:(nonnull NSNumber*)key
+RCT_EXPORT_METHOD(prepare:(NSString*)fileName
+                  withKey:(nonnull NSNumber*)key
+                  withOptions:(NSDictionary*)options
                   withCallback:(RCTResponseSenderBlock)callback) {
   NSError* error;
   NSURL* fileNameUrl;
   AVAudioPlayer* player;
-  
+
   if ([fileName hasPrefix:@"http"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
   }
   else {
     fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
   }
-    
+
   if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
               initWithContentsOfURL:fileNameUrl
               error:&error];
   }
-    
+
   if (player) {
     player.delegate = self;
     player.enableRate = YES;

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -122,12 +122,11 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
 
   if ([fileName hasPrefix:@"http"]) {
     fileNameUrl = [NSURL URLWithString:[fileName stringByRemovingPercentEncoding]];
+    NSData* data = [NSData dataWithContentsOfURL:fileNameUrl];
+    player = [[AVAudioPlayer alloc] initWithData:data error:&error];
   }
   else {
     fileNameUrl = [NSURL fileURLWithPath:[fileName stringByRemovingPercentEncoding]];
-  }
-
-  if (fileNameUrl) {
     player = [[AVAudioPlayer alloc]
               initWithContentsOfURL:fileNameUrl
               error:&error];

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -301,7 +301,6 @@ RCT_REMAP_METHOD(isHeadsetPlugged,
 }
 
 - (void)routeChange:(NSNotification*)notification {
-    NSLog(@"CALLBACK");
     BOOL headsetPlugged = [self isHeadsetPlugged];
 
     [self sendEventWithName:@"RouteChange" body:@{@"isHeadsetPlugged": headsetPlugged ? @YES : @NO}];

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -307,7 +307,6 @@ RCT_REMAP_METHOD(isHeadsetPlugged,
 }
 
 RCT_EXPORT_METHOD(addRouteChangeListener) {
-    NSLog(@"Observer registered");
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(routeChange:) // selector //@selector(callback)
                                                  name:@"AVAudioSessionRouteChangeNotification"
@@ -316,7 +315,6 @@ RCT_EXPORT_METHOD(addRouteChangeListener) {
 }
 
 RCT_EXPORT_METHOD(removeRouteChangeListener) {
-    NSLog(@"Observer unregistered");
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:@"AVAudioSessionRouteChangeNotification"
                                                 object: [AVAudioSession sharedInstance]];

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -99,7 +99,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     }
     player.setOnCompletionListener(new OnCompletionListener() {
       @Override
-      public void onCompletion(MediaPlayer mp) {
+      public synchronized void onCompletion(MediaPlayer mp) {
         if (!mp.isLooping()) {
           callback.invoke(true);
         }
@@ -107,7 +107,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     });
     player.setOnErrorListener(new OnErrorListener() {
       @Override
-      public boolean onError(MediaPlayer mp, int what, int extra) {
+      public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
         callback.invoke(false);
         return true;
       }

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -44,17 +44,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       callback.invoke(e);
       return;
     }
-    try {
-      player.prepare();
-    } catch (Exception exception) {
-              Log.e("RNSoundModule", "Exception", exception);
-
-       WritableMap e = Arguments.createMap();
-        e.putInt("code", -1);
-        e.putString("message", exception.getMessage());
-        callback.invoke(e);
-        return;
-    }
     this.playerPool.put(key, player);
     WritableMap props = Arguments.createMap();
     props.putDouble("duration", player.getDuration() * .001);
@@ -154,6 +143,14 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.setLooping(looping);
+    }
+  }
+
+  @ReactMethod
+  public void setSpeed(final Integer key, final Float speed) {
+    MediaPlayer player = this.playerPool.get(key);
+    if (player != null) {
+      player.setPlaybackParams(player.getPlaybackParams().setSpeed(speed));
     }
   }
 

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -87,16 +87,24 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
       return;
     }
     player.setOnCompletionListener(new OnCompletionListener() {
+      boolean callbackWasCalled = false;
+
       @Override
       public synchronized void onCompletion(MediaPlayer mp) {
         if (!mp.isLooping()) {
+          if (callbackWasCalled) return;
+          callbackWasCalled = true;
           callback.invoke(true);
         }
       }
     });
     player.setOnErrorListener(new OnErrorListener() {
+      boolean callbackWasCalled = false;
+
       @Override
       public synchronized boolean onError(MediaPlayer mp, int what, int extra) {
+        if (callbackWasCalled) return true;
+        callbackWasCalled = true;
         callback.invoke(false);
         return true;
       }

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -46,7 +46,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     }
 
     final RNSoundModule module = this;
-    
+
     player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       boolean callbackWasCalled = false;
 
@@ -134,7 +134,11 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         if (!mp.isLooping()) {
           if (callbackWasCalled) return;
           callbackWasCalled = true;
-          callback.invoke(true);
+          try {
+            callback.invoke(true);
+          } catch (Exception e) {
+              //Catches the exception: java.lang.RuntimeException·Illegal callback invocation from native module
+          }
         }
       }
     });

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -113,20 +113,22 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void pause(final Integer key) {
+  public void pause(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
     }
+    callback.invoke();
   }
 
   @ReactMethod
-  public void stop(final Integer key) {
+  public void stop(final Integer key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
       player.seekTo(0);
     }
+    callback.invoke();
   }
 
   @ReactMethod

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -182,6 +182,18 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     callback.invoke(player.getCurrentPosition() * .001, player.isPlaying());
   }
 
+  //turn speaker on
+  @ReactMethod
+  public void setSpeakerphoneOn(final Integer key, final Boolean speaker) {
+    MediaPlayer player = this.playerPool.get(key);
+    if (player != null) {
+      player.setAudioStreamType(AudioManager.STREAM_MUSIC);
+      AudioManager audioManager = (AudioManager)this.context.getSystemService(this.context.AUDIO_SERVICE);
+      audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+      audioManager.setSpeakerphoneOn(speaker);
+    }
+  }
+
   @ReactMethod
   public void enable(final Boolean enabled) {
     // no op

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.ExceptionsManagerModule;
 
 import java.io.File;
 import java.util.HashMap;
@@ -87,7 +88,13 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
         return true;
       }
     });
-    player.prepareAsync();
+
+    try {
+      player.prepareAsync();
+    } catch (IllegalStateException ignored) {
+      // When loading files from a file, we useMediaPlayer.create, which actually
+      // prepares the audio for us already. So we catch and ignore this error
+    }
   }
 
   protected MediaPlayer createMediaPlayer(final String fileName) {
@@ -111,6 +118,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
     File file = new File(fileName);
     if (file.exists()) {
       Uri uri = Uri.fromFile(file);
+      // Mediaplayer is already prepared here.
       return MediaPlayer.create(this.context, uri);
     }
     return null;

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.File;
@@ -35,7 +36,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void prepare(final String fileName, final Integer key, final Callback callback) {
+  public void prepare(final String fileName, final Integer key, final ReadableMap options, final Callback callback) {
     MediaPlayer player = createMediaPlayer(fileName);
     if (player == null) {
       WritableMap e = Arguments.createMap();

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,134 @@
+// Type definitions for react-native-sound
+// Project: https://github.com/zmxv/react-native-sound
+// Definitions by: Kyle Roach <https://github.com/iRoachie>
+// TypeScript Version: 2.3.2
+
+type AVAudioSessionCategory = 'Ambient' | 'SoloAmbient' | 'Playback' | 'Record' | 'PlayAndRecord' | 'AudioProcessing' | 'MultiRoute'
+
+export default class Sound {
+  static MAIN_BUNDLE: string
+  static DOCUMENT: string
+  static LIBRARY: string
+  static CACHES: string
+
+  /**
+   * Sets AVAudioSession category, which allows playing sound in background, 
+   * stop sound playback when phone is locked, etc. 
+   * Parameter options: "Ambient", "SoloAmbient", "Playback", "Record", "PlayAndRecord", "AudioProcessing", "MultiRoute".
+   * 
+   * @param category AVAudioSession category
+   * @param mixWithOthers Can be set to true to force mixing with other audio sessions.
+   */
+  static setCategory(category: AVAudioSessionCategory, mixWithOthers: boolean): void
+
+  /**
+   * @param filename Either absolute or relative path to the sound file
+   * @param basePath Optional base path of the file. Omit this or pass '' if filename is an absolute path. Otherwise, you may use one of the predefined directories: Sound.MAIN_BUNDLE, Sound.DOCUMENT, Sound.LIBRARY, Sound.CACHES.
+   * @param onError Optional callback function if loading file failed
+   */
+  constructor(filename: string, basePath: string, onError: (error: any) => void)
+
+  /**
+   * Return true if the sound has been loaded.
+   */
+  isLoaded(): boolean
+
+  /**
+   * Plays the loaded file
+   * @param onEnd - Optional callback function that gets called when the playback finishes successfully or an audio decoding error interrupts it
+   */
+  play(onEnd?: () => void): void
+
+  /**
+   * Pause the sound
+   * @param cb - Optional callback function that gets called when the sound has been paused.
+   */
+  pause(cb?: () => void): void
+
+  /**
+   * Stop playback and set the seek position to 0.
+   * @param cb - Optional callback function that gets called when the sound has been stopped.
+   */
+  stop(cb?: () => void): void
+
+  /**
+   * Release the audio player resource associated with the instance.
+   */
+  release(): void
+
+  /**
+   * Return the number of channels 
+   * (1 for mono and 2 for stereo sound), or -1 before the sound gets loaded.
+   */
+  getNumberOfChannels(): number
+
+  /**
+   * Return the volume of the audio player (not the system-wide volume),
+   * Ranges from 0.0 (silence) through 1.0 (full volume, the default)
+   */
+  getVolume(): number
+
+  /**
+   * Set the volume
+   * @param value - ranging from 0.0 (silence) through 1.0 (full volume)
+   */
+  setVolume(value: number): void
+
+  /**
+   * Return the stereo pan position of the audio player (not the system-wide pan)
+   * Ranges from -1.0 (full left) through 1.0 (full right). The default value is 0.0 (center)
+   */
+  getPan(): number
+
+  /**
+   * Set the pan value
+   * @param value - ranging from -1.0 (full left) through 1.0 (full right).
+   */
+  setPan(value: number): void
+
+  /**
+   * Return the loop count of the audio player. 
+   * The default is 0 which means to play the sound once. 
+   * A positive number specifies the number of times to return to the start and play again. 
+   * A negative number indicates an indefinite loop.
+   */
+  getNumberOfLoops(): number
+
+  /**
+   * Set the loop count
+   * @param value - 0 means to play the sound once. A positive number specifies the number of times to return to the start and play again (iOS only). A negative number indicates an indefinite loop (iOS and Android).
+   */
+  setNumberOfLoops(value: number): void
+
+  /**
+   * Callback will receive the current playback position in seconds and whether the sound is being played.
+   * @param cb 
+   */
+  getCurrentTime(cb?: (seconds: number, isPlaying: boolean) => void): void
+
+  /**
+   * Seek to a particular playback point in seconds.
+   * @param value 
+   */
+  setCurrentTime(value: number): void
+
+  /**
+   * Speed of the audio playback (iOS Only).
+   * @param value 
+   */
+  setSpeed(value: number): void
+
+  /**
+   * Whether to enable playback in silence mode (iOS only)
+   * @deprecated - Use the static method Sound.setCategory('Playback') instead which has the same effect.
+   * @param enabled 
+   */
+  enableInSilenceMode(enabled: boolean): void
+
+  /**
+   * Sets AVAudioSession category
+   * @deprecated
+   * @param value 
+   */
+  setCategory(value: AVAudioSessionCategory): void
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,4 +131,10 @@ export default class Sound {
    * @param value 
    */
   setCategory(value: AVAudioSessionCategory): void
+
+  /**
+   * Turn speaker phone on (android only)
+   * @param value
+   */
+  setSpeakerphoneOn(value: boolean): void
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare class Sound {
    * Register a listener for changes of headsetPluggedIn
    */
   static registerHeadsetPlugChangeListener(): void
-  
+
   /**
    * Unregister the attached listener for changes of headsetPluggedIn
    */
@@ -82,7 +82,7 @@ declare class Sound {
    * @param filename Either absolute or relative path to the sound file
    * @param basePath Optional base path of the file. Omit this or pass '' if filename is an absolute path. Otherwise, you may use one of the predefined directories: Sound.MAIN_BUNDLE, Sound.DOCUMENT, Sound.LIBRARY, Sound.CACHES.
    * @param onError Optional callback function if loading file failed
-   * @param options Optional feature 
+   * @param options Optional feature
    */
   constructor(filename: string, basePath: string, onError: (error: any) => void, options: { audioStreamType: AudioManagerAudioStreamType })
 
@@ -129,7 +129,7 @@ declare class Sound {
    * Return the time of audio (second)
    */
   getDuration(): number
-  
+
   /**
    * Return the volume of the audio player (not the system-wide volume),
    * Ranges from 0.0 (silence) through 1.0 (full volume, the default)
@@ -207,9 +207,9 @@ declare class Sound {
   setSpeakerphoneOn(value: boolean): void
 
   /**
-   * Return promise with isPlaying.
+   * Return whether the audio player is currently playing or not
    */
-  isPlaying(): Promise<boolean>
+  isPlaying(): boolean
 }
 
 export = Sound;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.2",
   "description": "React Native module for playing sound clips on iOS, Android, and Windows",
   "main": "sound.js",
+  "typings": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zmxv/react-native-sound.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sound",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "React Native module for playing sound clips on iOS, Android, and Windows",
   "main": "sound.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sound",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "React Native module for playing sound clips on iOS and Android",
   "main": "sound.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-sound",
-  "version": "0.10.0",
-  "description": "React Native module for playing sound clips on iOS and Android",
+  "version": "0.10.1",
+  "description": "React Native module for playing sound clips on iOS, Android, and Windows",
   "main": "sound.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sound",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "React Native module for playing sound clips on iOS, Android, and Windows",
   "main": "sound.js",
   "repository": {

--- a/sound.js
+++ b/sound.js
@@ -7,7 +7,7 @@ var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSourc
 var nextKey = 0;
 
 function isRelativePath(path) {
-  return !/^\//.test(path);
+  return !/^(\/|http(s?))/.test(path);
 }
 
 function Sound(filename, basePath, onError) {

--- a/sound.js
+++ b/sound.js
@@ -135,7 +135,7 @@ Sound.prototype.setNumberOfLoops = function(value) {
 Sound.prototype.setSpeed = function(value) {
   this._setSpeed = value;
   if (this._loaded) {
-    if (!IsAndroid && !IsWindows) {
+    if (!IsWindows) {
       RNSound.setSpeed(this._key, value);
     }
   }

--- a/sound.js
+++ b/sound.js
@@ -155,6 +155,13 @@ Sound.prototype.setCurrentTime = function(value) {
   return this;
 };
 
+// android only
+Sound.prototype.setSpeakerphoneOn = function(value) {
+  if (IsAndroid) {
+    RNSound.setSpeakerphoneOn(this._key, value);
+  }
+};
+
 // ios only
 
 // This is deprecated.  Call the static one instead.

--- a/sound.js
+++ b/sound.js
@@ -10,7 +10,7 @@ function isRelativePath(path) {
   return !/^(\/|http(s?))/.test(path);
 }
 
-function Sound(filename, basePath, onError) {
+function Sound(filename, basePath, onError, options) {
   var asset = resolveAssetSource(filename);
   if (asset) {
     this._filename = asset.uri;
@@ -31,7 +31,7 @@ function Sound(filename, basePath, onError) {
   this._pan = 0;
   this._numberOfLoops = 0;
   this._speed = 1;
-  RNSound.prepare(this._filename, this._key, (error, props) => {
+  RNSound.prepare(this._filename, this._key, options || {}, (error, props) => {
     if (props) {
       if (typeof props.duration === 'number') {
         this._duration = props.duration;

--- a/sound.js
+++ b/sound.js
@@ -60,16 +60,16 @@ Sound.prototype.play = function(onEnd) {
   return this;
 };
 
-Sound.prototype.pause = function() {
+Sound.prototype.pause = function(callback) {
   if (this._loaded) {
-    RNSound.pause(this._key);
+    RNSound.pause(this._key, () => { callback && callback() });
   }
   return this;
 };
 
-Sound.prototype.stop = function() {
+Sound.prototype.stop = function(callback) {
   if (this._loaded) {
-    RNSound.stop(this._key);
+    RNSound.stop(this._key, () => { callback && callback() });
   }
   return this;
 };

--- a/windows/RNSoundModule/RNSoundModule/RNSound.cs
+++ b/windows/RNSoundModule/RNSoundModule/RNSound.cs
@@ -178,7 +178,7 @@ namespace RNSoundModule
         }
 
         [ReactMethod]
-        public void pause(int key)
+        public void pause(int key, ICallback callback)
         {
             MediaPlayer player = null;
 
@@ -190,10 +190,11 @@ namespace RNSoundModule
             {
                 player.Pause();
             }
+            callback.Invoke();
         }
 
         [ReactMethod]
-        public void stop(int key)
+        public void stop(int key, ICallback callback)
         {
             MediaPlayer player = null;
 
@@ -204,6 +205,7 @@ namespace RNSoundModule
 
             player.Pause();
             player.PlaybackSession.Position = new TimeSpan(0);
+            callback.Invoke();
         }
 
         [ReactMethod]

--- a/windows/RNSoundModule/RNSoundModule/RNSound.cs
+++ b/windows/RNSoundModule/RNSoundModule/RNSound.cs
@@ -142,6 +142,7 @@ namespace RNSoundModule
         [ReactMethod]
         public void play(int key, ICallback callback)
         {
+            Boolean callbackWasCalled = false;
             MediaPlayer player = null;
             Debug.WriteLine("play()");
 
@@ -167,6 +168,8 @@ namespace RNSoundModule
             player.MediaEnded +=
                 delegate
                 {
+                    if (callbackWasCalled) return;
+                    callbackWasCalled = true;
                     Debug.WriteLine("Media Ended");
                     callback.Invoke(true);
                 };


### PR DESCRIPTION
- This implements `isPlaying()` for both android and ios.

- This modifies `setSpeed()` for android, not to autoplay when `setSpeed()` is called

- This fixes problem of not being able to pause when sound is autoplayed by `setSpeed()`

- This solves inconsistency between ios and android on how `setSpeed()` works.
    -  Originally, for android
        - calling `setSpeed()` on paused player invokes autoplay.
    - for ios, 
        - calling `setSpeed()` on a paused player does not invoke autoplay.

- This Pull Request includes PR #211 .
    - Please refer to PR #211 . It met all the requests but was closed due to late reply.
