### PR TITLE
Fix typo in HEADER_SEARCH_PATHS for "node_modules"

### DIFF
--- a/RNSound.xcodeproj/project.pbxproj
+++ b/RNSound.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../react-native/React/**",
-					"$(SRCROOT)/node_moduels/react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;


### PR DESCRIPTION
Simple fix to change "node_moduels" to "node_modules" in the Xcode project. Should address #210 