### PR TITLE
Fix for zmxv/react-native-sound#362

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -33,7 +33,7 @@ function Sound(filename, basePath, onError, options) {
   }
 
   this._loaded = false;
-  this._key = djb2Code(filename);
+  this._key = asset ? filename : djb2Code(filename); //if the file is an asset, use the asset number as the key
   this._duration = -1;
   this._numberOfChannels = -1;
   this._volume = 1;


### PR DESCRIPTION
This fixes the issue where preloading several assets results in always playing the last preloaded sound.