### PR TITLE
Fix java.lang.IllegalStateException - prepareAsync called in state 8

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -179,10 +179,17 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
 
     File file = new File(fileName);
     if (file.exists()) {
-      Uri uri = Uri.fromFile(file);
-      // Mediaplayer is already prepared here.
-      return MediaPlayer.create(this.context, uri);
+      mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+      Log.i("RNSoundModule", fileName);
+      try {
+          mediaPlayer.setDataSource(fileName);
+      } catch(IOException e) {
+          Log.e("RNSoundModule", "Exception", e);
+          return null;
+      }
+      return mediaPlayer;
     }
+    
     return null;
   }
 


### PR DESCRIPTION
I am not sure why were we using `MediaPlayer.create` and then also call prepare on the returned `MediaPlayer`. Although it is documented that we were catching the exception to avoid the app from aborting, but we can just use `setDataSource` for the file name as well. I was able to test it and confirm that no exception was thrown and the sound was played as expected by using the `setDataSource`. Below is the stack trace of the exception that is fixed

```java
02-04 19:49:49.730 14547-14624/com.myapp E/MediaPlayer: prepareAsync called in state 8, mPlayer(0x7f98d660)
02-04 19:49:49.731 14547-14624/com.myapp E/RNSoundModule: Exception
                                                              java.lang.IllegalStateException
                                                                  at android.media.MediaPlayer._prepare(Native Method)
                                                                  at android.media.MediaPlayer.prepare(MediaPlayer.java:1184)
                                                                  at com.zmxv.RNSound.RNSoundModule.prepare(RNSoundModule.java:130)
                                                                  at java.lang.reflect.Method.invoke(Native Method)
                                                                  at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:374)
                                                                  at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:162)
                                                                  at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
                                                                  at android.os.Handler.handleCallback(Handler.java:751)
                                                                  at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
                                                                  at android.os.Looper.loop(Looper.java:154)
                                                                  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:194)
                                                                  at java.lang.Thread.run(Thread.java:761)
```