### PR TITLE
Implements isPlaying() for android and ios

### DIFF
--- a/RNSound/RNSound.h
+++ b/RNSound/RNSound.h
@@ -5,7 +5,9 @@
 #endif
 
 #import <AVFoundation/AVFoundation.h>
+#import <React/RCTEventEmitter.h>
 
+@interface RNSound : RCTEventEmitter <RCTBridgeModule, AVAudioPlayerDelegate>
 @interface RNSound : NSObject <RCTBridgeModule, AVAudioPlayerDelegate>
 @property (nonatomic, weak) NSNumber* _key;
 @end

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -76,6 +76,7 @@
   if (key == nil) return;
 
   @synchronized(key) {
+    [self setOnPlay:NO forPlayerKey:key];
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {
       callback(@[@(flag)]);
@@ -85,6 +86,11 @@
 }
 
 RCT_EXPORT_MODULE();
+
+-(NSArray<NSString *> *)supportedEvents
+  {
+    return @[@"onPlayChange"];
+  }
 
 -(NSDictionary *)constantsToExport {
   return @{@"IsAndroid": [NSNumber numberWithBool:NO],
@@ -217,6 +223,7 @@ RCT_EXPORT_METHOD(play:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   if (player) {
     [[self callbackPool] setObject:[callback copy] forKey:key];
     [player play];
+    [self setOnPlay:YES forPlayerKey:key];
   }
 }
 
@@ -298,5 +305,7 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
 {
     return YES;
 }
-
+- (void)setOnPlay:(BOOL)isPlaying forPlayerKey:(nonnull NSNumber*)playerKey {
+  [self sendEventWithName:@"onPlayChange" body:@{@"isPlaying": isPlaying ? @YES : @NO, @"playerKey": playerKey}];
+}
 @end

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,11 @@ declare class Sound {
    * @param value
    */
   setSpeakerphoneOn(value: boolean): void
+
+  /**
+   * Whether the player is playing or not.
+   */
+  isPlaying(): boolean
 }
 
 export = Sound;

--- a/sound.js
+++ b/sound.js
@@ -90,13 +90,6 @@ Sound.prototype.isLoaded = function() {
 Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
     RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
-    if (IsAndroid) {
-      // For Android
-      // Manually call native setSpeed() after native play() to apply current speed.
-      // Native setSpeed method should be called only if the media player is already playing.
-      // To prevent android from playing automatically when setSpeed is called.
-      RNSound.setSpeed(this._key, this._speed);
-    }
   } else {
     onEnd && onEnd(false);
   }
@@ -213,15 +206,8 @@ Sound.prototype.setNumberOfLoops = function(value) {
 Sound.prototype.setSpeed = function(value) {
   this._speed = value;
   if (this._loaded) {
-    if (!IsWindows && !IsAndroid) {
+    if (!IsWindows) {
       RNSound.setSpeed(this._key, value);
-    } else if (IsAndroid) {
-      // For Android
-      // Call native setSpeed method only if the media player is already playing.
-      // To prevent android from playing automatically when setSpeed is called.
-      if (this._playing) {
-        RNSound.setSpeed(this._key, value);
-      }
     }
   }
   return this;


### PR DESCRIPTION
- This implements isPlaying() for both android and ios.
- This correctly handles timing issues between `js` and native code by using event emitter.
- This PR reflects comment given in PR  #349 .
 - @trepidity . More features from PR #349 will be added as separate PR as soon as this PR is merged to upstream.