### PR TITLE
Change playerPool key to Double

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -59,7 +59,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     final RNSoundModule module = this;
 
     if (module.category != null) {
-      Double category = null;
+      Integer category = null;
       switch (module.category) {
         case "Playback":
           category = AudioManager.STREAM_MUSIC;

--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -25,13 +25,13 @@ import java.io.IOException;
 import android.util.Log;
 
 public class RNSoundModule extends ReactContextBaseJavaModule implements AudioManager.OnAudioFocusChangeListener {
-  Map<Integer, MediaPlayer> playerPool = new HashMap<>();
+  Map<Double, MediaPlayer> playerPool = new HashMap<>();
   ReactApplicationContext context;
   final static Object NULL = null;
   String category;
   Boolean mixWithOthers = true;
 
-  Integer focusedPlayerKey;
+  Double focusedPlayerKey;
   Boolean wasPlayingBeforeFocusChange;
 
   public RNSoundModule(ReactApplicationContext context) {
@@ -46,7 +46,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void prepare(final String fileName, final Integer key, final ReadableMap options, final Callback callback) {
+  public void prepare(final String fileName, final Double key, final ReadableMap options, final Callback callback) {
     MediaPlayer player = createMediaPlayer(fileName);
     if (player == null) {
       WritableMap e = Arguments.createMap();
@@ -59,7 +59,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     final RNSoundModule module = this;
 
     if (module.category != null) {
-      Integer category = null;
+      Double category = null;
       switch (module.category) {
         case "Playback":
           category = AudioManager.STREAM_MUSIC;
@@ -187,7 +187,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void play(final Integer key, final Callback callback) {
+  public void play(final Double key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
       if (callback != null) {
@@ -202,7 +202,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     // Request audio focus in Android system
     if (!this.mixWithOthers) {
       AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-      
+
       audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
 
       this.focusedPlayerKey = key;
@@ -243,25 +243,25 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void pause(final Integer key, final Callback callback) {
+  public void pause(final Double key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
     }
-    
+
     if (callback != null) {
       callback.invoke();
     }
   }
 
   @ReactMethod
-  public void stop(final Integer key, final Callback callback) {
+  public void stop(final Double key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null && player.isPlaying()) {
       player.pause();
       player.seekTo(0);
     }
-    
+
     // Release audio focus in Android system
     if (!this.mixWithOthers && key == this.focusedPlayerKey) {
       AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
@@ -272,7 +272,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void reset(final Integer key) {
+  public void reset(final Double key) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.reset();
@@ -280,7 +280,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void release(final Integer key) {
+  public void release(final Double key) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.release();
@@ -295,7 +295,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void setVolume(final Integer key, final Float left, final Float right) {
+  public void setVolume(final Double key, final Float left, final Float right) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.setVolume(left, right);
@@ -325,7 +325,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void setLooping(final Integer key, final Boolean looping) {
+  public void setLooping(final Double key, final Boolean looping) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.setLooping(looping);
@@ -333,7 +333,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void setSpeed(final Integer key, final Float speed) {
+  public void setSpeed(final Double key, final Float speed) {
 	if (android.os.Build.VERSION.SDK_INT < 23) {
 	  Log.w("RNSoundModule", "setSpeed ignored due to sdk limit");
 	  return;
@@ -346,7 +346,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void setCurrentTime(final Integer key, final Float sec) {
+  public void setCurrentTime(final Double key, final Float sec) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.seekTo((int)Math.round(sec * 1000));
@@ -354,7 +354,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   }
 
   @ReactMethod
-  public void getCurrentTime(final Integer key, final Callback callback) {
+  public void getCurrentTime(final Double key, final Callback callback) {
     MediaPlayer player = this.playerPool.get(key);
     if (player == null) {
       callback.invoke(-1, false);
@@ -365,7 +365,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
 
   //turn speaker on
   @ReactMethod
-  public void setSpeakerphoneOn(final Integer key, final Boolean speaker) {
+  public void setSpeakerphoneOn(final Double key, final Boolean speaker) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
       player.setAudioStreamType(AudioManager.STREAM_MUSIC);
@@ -389,7 +389,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   public void onAudioFocusChange(int focusChange) {
     if (!this.mixWithOthers) {
       MediaPlayer player = this.playerPool.get(this.focusedPlayerKey);
-      
+
       if (player != null) {
         if (focusChange <= 0) {
             this.wasPlayingBeforeFocusChange = player.isPlaying();


### PR DESCRIPTION
Encountered an issue when preloading multiple sounds from URLs that would cause several sounds to play whatever file was preloaded last. 

Appears this was caused by the chosen key for a sound exceeding the Java Integer size, leading to collisions when multiple keys were passed to the Java module as the max Integer size. Our solution was to change the keys used for the player pool from Integer to Double to avoid such collisions.

Believe this should also fix #362