### PR TITLE
Change callbacks to promises and leave windows

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,12 @@
+export function isRelativePath(path) {
+  return !/^(\/|http(s?)|asset)/.test(path);
+}
+
+export function djb2Code(str) {
+  var hash = 5381, i, char;
+  for (i = 0; i < str.length; i++) {
+      char = str.charCodeAt(i);
+      hash = ((hash << 5) + hash) + char; /* hash * 33 + c */
+  }
+  return hash;
+}


### PR DESCRIPTION
This is just a proposal and i'm using it in a current project. Actually, i really thinks callbacks aren't the best way to handle async actions in Javascript so i tried to wrapped all functions from RNSound within Promises so user can use the async/await syntax and tools like Redux Saga with no modifications. Also removed support from Windows (who still use it?).

Just want to know what do you think about this update then i can create all the tests and update documentation.

I did tests with remote files only but if you approve this change i can also test with all the options from the old version. 

I also changed the code to use the new ES6 syntax with classes and arrow functions.

**Examples:**

Old: 
```js
Sound.prototype.pause = function(callback) {
  if (this._loaded) {
    RNSound.pause(this._key, () => {
      this._playing = false;
      callback && callback();
    });
  }
  return this;
};
```

New:
```js
pause = () => new Promise((resolve, reject) => {
  if (!this.loaded) return reject();

  RNSound.pause(this.key, () => {
    this.playing = false;
    resolve();
  });
})
```

I'm waiting for feedbacks :)