### PR TITLE
fix react-native-windows path definition

### DIFF
--- a/windows/RNSoundModule/RNSoundModule/RNSound.cs
+++ b/windows/RNSoundModule/RNSoundModule/RNSound.cs
@@ -114,7 +114,7 @@ namespace RNSoundModule
                     {
                         file = await InstallationFolder.GetFileAsync(@"Assets\" + fileName);
                     }
-                    catch (Exception e) { }
+                    catch (Exception) { }
 
                     if (file == null)
                     {
@@ -122,7 +122,7 @@ namespace RNSoundModule
                         {
                             file = await LocalFolder.GetFileAsync(fileName);
                         }
-                        catch (Exception e) { }
+                        catch (Exception) { }
 
                     }
 

--- a/windows/RNSoundModule/RNSoundModule/RNSoundModule.csproj
+++ b/windows/RNSoundModule/RNSoundModule/RNSoundModule.csproj
@@ -16,6 +16,10 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  	<ReactWindowsRoot>..\..\node_modules</ReactWindowsRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('..\..\..\..\react-native-windows')">
+	<ReactWindowsRoot>..\..\..\..</ReactWindowsRoot>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -113,7 +117,7 @@
     <EmbeddedResource Include="Properties\RNSoundModule.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="$(ReactWindowsRoot)\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>

--- a/windows/RNSoundModule/RNSoundModule/project.json
+++ b/windows/RNSoundModule/RNSoundModule/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.0.8"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
**- About our project** 
In our project we use react-native-sound and some other "Native" packages, and we provide automatic CI process for three platforms: IOS, Android and Windows UWP. 
We had some difficulties with setting up CI for Windows UWP. 

**- Notice** 
Before describing the problem and solution, I want to warn you that I'm not a professional windows developer, and maybe my actions were not the most faithful. 

**- About problem** 
react-native-sound requires a reference to the react-native-windows package. And there are two possible locations for the folder with a react-native-windows package: 

First: 
react-native-windows can be located in the node_modules folder in the most react-native-sound, then in the file 
react-native-sound/windows/RNSoundModule/RNSoundModule/RNSoundModule.csproj on the line 116 of code should have such path 
`<ProjectReference Include="..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj"> `
(The folder react-native-windows lies on three levels above and in the folder node_modules) 

Second 
The folder react-native-windows can be located next to the folder react-native-device-info in node_modules of another project (as in our case) 
In this case, the path to the react-native-sound/windows/RNSoundModule/RNSoundModule/RNSoundModule.csproj on the 116 line of code should have this path 
`<ProjectReference Include = "..\..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj"> `
(The folder react-native-windows is four levels higher) 

If we build our project using Visual Studio 2017, the process of restoring references to the dependency modules occurs (it's incomprehensible to me) 

And path 
`..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj `
Automatically turns into 
`..\..\..\..\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj `

And projects are going well! 

**But** we use an automatic CI system based on the **msbuild** console utility from Microsoft 

And although Visual Studio is based on msbuild, when assembling through it, there is no restoring of references (for two days of searching I have not found the answer why this works exactly the same way and how the mechanism for restoring links in the msbuild console starts) 

**- Solution** 
In /windows/RNSoundModule/RNSoundModule/RNSoundModule.csproj  file, replace the root path of the variable 

```
<ProjectReference Include="..\..\..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj"> 
<ProjectReference Include="$(ReactWindowsRoot)\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj"> 
```

And add a special condition for updating this route 
```
< PropertyGroup >
  <ReactWindowsRoot>..\..\node_modules</ReactWindowsRoot> 
</PropertyGroup> 
```
```
<PropertyGroup Condition="Exists('..\..\..\react-native-windows')"> 
  <ReactWindowsRoot>..\..\..</ReactWindowsRoot> 
</PropertyGroup> 
```
This change guarantees us the correct path definition to react-native-windows 

**P.S.** - Thank you for a good package if you have ideas and how best to solve or bypass this problem I will be glad to discuss them
