### PR TITLE
fixed after link still need manual edit android/app/build.gradle

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,13 @@
   "license": "MIT",
   "peerDependencies": {
     "react-native": ">=0.8.0"
+  },
+  "rnpm": {
+    "commands": {
+      "prelink": "node node_modules/react-native-sound/scripts/patch"
+    }
+  },
+  "dependencies": {
+    "mpath": "^0.4.0"
   }
 }

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -1,0 +1,15 @@
+const patch = require('mpatch')
+const inquirer = require('inquirer')
+const recipes = {
+	'android/**/build.gradle': [{
+      pattern: 'dependencies {',
+      patch: `
+		compile project(':react-native-sound')`
+    }]
+}
+
+Object.keys(recipes).forEach(file => {
+    patch(file, [].concat(recipes[file]))
+})
+
+console.log('done!')


### PR DESCRIPTION
after run `react-native link react-native-sound` still need to edit app/android/build.gradle
now add  a prelink command in package.json,so after linked don't need to edit app/android/build.gradle