### PR TITLE
Remove objective c literals that were not backwards compatible with iOS8

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -1,4 +1,4 @@
-/>>uu#import "RNSound.h"
+#import "RNSound.h"
 
 #if __has_include("RCTUtils.h")
     #import "RCTUtils.h"

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -79,7 +79,7 @@
     [self setOnPlay:NO forPlayerKey:key];
     RCTResponseSenderBlock callback = [self callbackForKey:key];
     if (callback) {
-      callback(@[@(flag)]);
+      callback([NSArray arrayWithObjects:[NSNumber numberWithBool:flag], nil]);
       [[self callbackPool] removeObjectForKey:key];
     }
   }
@@ -88,17 +88,17 @@
 RCT_EXPORT_MODULE();
 
 -(NSArray<NSString *> *)supportedEvents
-  {
-    return @[@"onPlayChange"];
-  }
+{
+  return [NSArray arrayWithObjects: @"onPlayChange", nil];
+}
 
 -(NSDictionary *)constantsToExport {
-  return @{@"IsAndroid": [NSNumber numberWithBool:NO],
-           @"MainBundlePath": [[NSBundle mainBundle] bundlePath],
-           @"NSDocumentDirectory": [self getDirectory:NSDocumentDirectory],
-           @"NSLibraryDirectory": [self getDirectory:NSLibraryDirectory],
-           @"NSCachesDirectory": [self getDirectory:NSCachesDirectory],
-           };
+  return [NSDictionary dictionaryWithObjectsAndKeys:
+          [NSNumber numberWithBool:NO], @"IsAndroid",
+          [[NSBundle mainBundle] bundlePath], @"MainBundlePath",
+          [self getDirectory:NSDocumentDirectory], @"NSDocumentDirectory",
+          [self getDirectory:NSLibraryDirectory], @"NSLibraryDirectory",
+          [self getDirectory:NSCachesDirectory], @"NSCachesDirectory", nil];
 }
 
 RCT_EXPORT_METHOD(enable:(BOOL)enabled) {
@@ -208,10 +208,9 @@ RCT_EXPORT_METHOD(prepare:(NSString*)fileName
     player.enableRate = YES;
     [player prepareToPlay];
     [[self playerPool] setObject:player forKey:key];
-    callback(@[[NSNull null], @{@"duration": @(player.duration),
-                                @"numberOfChannels": @(player.numberOfChannels)}]);
+    callback([NSArray arrayWithObjects:[NSNull null], [NSDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithDouble:player.duration], @"duration", [NSNumber numberWithUnsignedInteger:player.numberOfChannels], @"numberOfChannels", nil], nil]);
   } else {
-    callback(@[RCTJSErrorFromNSError(error)]);
+    callback([NSArray arrayWithObjects:RCTJSErrorFromNSError(error), nil]);
   }
 }
 
@@ -231,7 +230,7 @@ RCT_EXPORT_METHOD(pause:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBl
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
     [player pause];
-    callback(@[]);
+    callback([NSArray array]);
   }
 }
 
@@ -240,7 +239,7 @@ RCT_EXPORT_METHOD(stop:(nonnull NSNumber*)key withCallback:(RCTResponseSenderBlo
   if (player) {
     [player stop];
     player.currentTime = 0;
-    callback(@[]);
+    callback([NSArray array]);
   }
 }
 
@@ -295,9 +294,9 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
                   withCallback:(RCTResponseSenderBlock)callback) {
   AVAudioPlayer* player = [self playerForKey:key];
   if (player) {
-    callback(@[@(player.currentTime), @(player.isPlaying)]);
+    callback([NSArray arrayWithObjects:[NSNumber numberWithDouble:player.currentTime], [NSNumber numberWithBool: player.isPlaying], nil]);
   } else {
-    callback(@[@(-1), @(false)]);
+    callback([NSArray arrayWithObjects:[NSNumber numberWithInteger:-1], [NSNumber numberWithBool:NO], nil]);
   }
 }
 
@@ -306,6 +305,6 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
     return YES;
 }
 - (void)setOnPlay:(BOOL)isPlaying forPlayerKey:(nonnull NSNumber*)playerKey {
-  [self sendEventWithName:@"onPlayChange" body:@{@"isPlaying": isPlaying ? @YES : @NO, @"playerKey": playerKey}];
+  [self sendEventWithName:@"onPlayChange" body:[NSDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithBool: isPlaying ? YES : NO], @"isPlaying", playerKey, @"playerKey", nil]];
 }
 @end


### PR DESCRIPTION
This addresses an open issue #266 
When removing the object literals from the code and using basic objective-c class methods, we saw that the iOS 8 crash issue was resolved.