### PR TITLE
Backward compatibility.

### DIFF
--- a/RNSound/RNSound.h
+++ b/RNSound/RNSound.h
@@ -5,7 +5,12 @@
 #endif
 
 #import <AVFoundation/AVFoundation.h>
+
+#if __has_include(<React/RCTEventEmitter.h>)
 #import <React/RCTEventEmitter.h>
+#else
+#import "RCTEventEmitter.h"
+#endif
 
 @interface RNSound : RCTEventEmitter <RCTBridgeModule, AVAudioPlayerDelegate>
 @property (nonatomic, weak) NSNumber* _key;


### PR DESCRIPTION
Seems like the changes in https://github.com/zmxv/react-native-sound/pull/366 broke the backward compatibility with react-native: 0.35 (the version my project is using). This change seems to have fixed it in my project, so creating a PR in case anybody else runs into this issue.