### PR TITLE
Use incremental keys for sounds instead of filename hash

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -7,18 +7,10 @@ var IsWindows = RNSound.IsWindows;
 var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSource");
 var eventEmitter = new ReactNative.NativeEventEmitter(RNSound);
 
+var nextKey = 0;
+
 function isRelativePath(path) {
   return !/^(\/|http(s?)|asset)/.test(path);
-}
-
-// Hash function to compute key from the filename
-function djb2Code(str) {
-  var hash = 5381, i, char;
-  for (i = 0; i < str.length; i++) {
-      char = str.charCodeAt(i);
-      hash = ((hash << 5) + hash) + char; /* hash * 33 + c */
-  }
-  return hash;
 }
 
 function Sound(filename, basePath, onError, options) {
@@ -59,7 +51,7 @@ function Sound(filename, basePath, onError, options) {
   }
 
   this._loaded = false;
-  this._key = asset ? filename : djb2Code(filename); //if the file is an asset, use the asset number as the key
+  this._key = nextKey++;
   this._playing = false;
   this._duration = -1;
   this._numberOfChannels = -1;


### PR DESCRIPTION
This commit https://github.com/zmxv/react-native-sound/commit/42f329544d8f4d129635d70d12038848c6c7a8e4 changes the behaviour of the library in a likely undesirable way. If you create multiple sounds with the same filename, they are all given the same `_key` property, a hash of the filename. I manage a product that requires multiple instances of the same sound, and now they're all just different javascript objects controlling the same single native sound instance. 

This PR simply goes back to assigning the `_key` value using an incremental value. 

Why was `_key` changed to using a hash function? I can imagine there being reasons to do so, but I'm unsure @varungupta85  