### PR TITLE
add cookie support for downloading sound with session based authentication

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion 26
+  buildToolsVersion "26.0.3"
 
   defaultConfig {
     minSdkVersion 16


### PR DESCRIPTION
I am using react-native-sound in a scenario which needs to send cookies / session info to download the remote audio files. This pull requests adds support to include cookies in the request for downloading audio files from a remote server.