### PR TITLE
Allow the override of compileSdkVersion, buildToolsVersion, minSdkVersion and targetSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,16 +1,20 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 26
-def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.2"
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 def DEFAULT_TARGET_SDK_VERSION              = 26
 
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+  compileSdkVersion safeExtGet("compileSdkVersion", 23)
+  buildToolsVersion safeExtGet("buildToolsVersion", "23.0.1")
+
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    minSdkVersion safeExtGet("minSdkVersion", 16)
+    targetSdkVersion safeExtGet("targetSdkVersion", 23)
     versionCode 1
     versionName "1.0"
     ndk {


### PR DESCRIPTION
Allow versions to be set via config, rather than hard coded. This is becoming the standard for React Native modules.

Config example, in build.gradle:

```
buildscript {
    ext {
	buildToolsVersion = "27.0.3"
	minSdkVersion = 21
	compileSdkVersion = 27
	targetSdkVersion = 26
	supportLibVersion = "27.1.1"
    }
}
```

This would also remove the need for the following to be merged:  #520 #502 #487 #459 