### PR TITLE
Compatibility changes to the build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,5 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.12.+'
+  implementation 'com.facebook.react:react-native:0.12.+'
 }


### PR DESCRIPTION
- Updated the build gradle to use root project configurations if they exist
- Replaced deprecated dependency keyword `compile` to use the supported version `implementation`