### PR TITLE
Release playerPool when reload

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -316,6 +316,13 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
       }
     }
   }
+	
+  @Override
+  public void onCatalystInstanceDestroy() {
+    for (Map.Entry<String, String> entry : this.playerPool.entrySet()) {
+      release(entry.getKey());
+    }
+  }
 
   @ReactMethod
   public void setVolume(final Double key, final Float left, final Float right) {


### PR DESCRIPTION
If you reload on android, the players would continue and overlap. Need to clean up on reload.