### PR TITLE
Remove misleading reset() in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ whoosh.play((success) => {
     console.log('successfully finished playing');
   } else {
     console.log('playback failed due to audio decoding errors');
-    // reset the player to its uninitialized state (android only)
-    // this is the only option to recover after an error occured and use the player again
-    whoosh.reset();
   }
 });
 });


### PR DESCRIPTION
Actually you can not play() after reset(). Reset would [clear the completion event listener](https://stackoverflow.com/questions/19548471/mediaplayer-oncompletionlistener-never-being-triggered#comment29014599_19548471) and thus make the media player be in a stopped state, which needs to `prepare again to be playable`.

![image](https://user-images.githubusercontent.com/615282/52172048-9c2eaa80-27a2-11e9-94a3-15c796ba7731.png)
