### PR TITLE
Fix getSystemVolume on Android for parity with iOS: (volume) instead of (NULL, volume)

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -345,7 +345,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
     try {
       AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 
-      callback.invoke(NULL, (float) audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) / audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
+      callback.invoke((float) audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) / audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC));
     } catch (Exception error) {
       WritableMap e = Arguments.createMap();
       e.putInt("code", -1);


### PR DESCRIPTION
The call back for getSystemVolume is currently being called with (NULL, systemVolume).

This does not match the defined API, nor what iOS does.

[callback {?function(systemVolume)}](https://github.com/zmxv/react-native-sound/wiki/API#getsystemvolumecallback)

This will fix this issue: https://github.com/zmxv/react-native-sound/issues/496