### PR TITLE
Fix reference to React-Core.

### DIFF
--- a/RNSound.podspec
+++ b/RNSound.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
   
-  s.dependency 'React/Core'
+  s.dependency 'React-Core'
   
   s.subspec 'Core' do |ss|
     ss.source_files     = "RNSound/*.{h,m}"


### PR DESCRIPTION
Since React Native introduced Podfiles the correct dependency for React Core is now React-Core and not React/Core.

This fixed an issue I was experiencing on a new project started with `react-native init --version 0.60.0-rc.1 name`