### PR TITLE
Escape basePath when bundleName contains spaces

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -194,17 +194,18 @@ RCT_EXPORT_METHOD(prepare
     NSError *error;
     NSURL *fileNameUrl;
     AVAudioPlayer *player;
+    NSString* fileNameEscaped = [fileName stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 
-    if ([fileName hasPrefix:@"http"]) {
-        fileNameUrl = [NSURL URLWithString:fileName];
+    if ([fileNameEscaped hasPrefix:@"http"]) {
+        fileNameUrl = [NSURL URLWithString:fileNameEscaped];
         NSData *data = [NSData dataWithContentsOfURL:fileNameUrl];
         player = [[AVAudioPlayer alloc] initWithData:data error:&error];
-    } else if ([fileName hasPrefix:@"ipod-library://"]) {
-        fileNameUrl = [NSURL URLWithString:fileName];
+    } else if ([fileNameEscaped hasPrefix:@"ipod-library://"]) {
+        fileNameUrl = [NSURL URLWithString:fileNameEscaped];
         player = [[AVAudioPlayer alloc] initWithContentsOfURL:fileNameUrl
                                                         error:&error];
     } else {
-        fileNameUrl = [NSURL URLWithString:fileName];
+        fileNameUrl = [NSURL URLWithString:fileNameEscaped];
         player = [[AVAudioPlayer alloc] initWithContentsOfURL:fileNameUrl
                                                         error:&error];
     }


### PR DESCRIPTION
On Xcode 11 if you have a bundleName with a space (eg. "Test App") the bundle name will have a space (eg. "Test App.app").
Without escaping, the library is unable to load the sound file. 

Solves issues: [#64](https://github.com/zmxv/react-native-sound/issues/64), [#136](https://github.com/zmxv/react-native-sound/issues/136)