### PR TITLE
Usage of `setAudioStreamType` is deprecated

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -409,7 +409,6 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
   public void setSpeakerphoneOn(final Double key, final Boolean speaker) {
     MediaPlayer player = this.playerPool.get(key);
     if (player != null) {
-      player.setAudioStreamType(AudioManager.STREAM_MUSIC);
       AudioManager audioManager = (AudioManager)this.context.getSystemService(this.context.AUDIO_SERVICE);
       if(speaker){
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);


### PR DESCRIPTION
This change removes usage of stream types on android, which is deprecated as documented in runtime logs:

```
MediaPlayer: Use of stream types is deprecated for operations other than volume control
MediaPlayer: See the documentation of setAudioStreamType() for what to use instead with android.media.AudioAttributes to qualify your playback use case
```

https://developer.android.com/reference/android/media/MediaPlayer#setAudioStreamType(int)