### PR TITLE
Send an event when sound playing was interrupted

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -23,17 +23,20 @@
     if (audioSessionInterruptionType == AVAudioSessionInterruptionTypeEnded) {
         if (player && player.isPlaying) {
             [player play];
+            [self setOnPlay:YES forPlayerKey:self._key];
         }
     }
     if (audioSessionRouteChangeReason ==
         AVAudioSessionRouteChangeReasonOldDeviceUnavailable) {
         if (player) {
             [player pause];
+            [self setOnPlay:NO forPlayerKey:self._key];
         }
     }
     if (audioSessionInterruptionType == AVAudioSessionInterruptionTypeBegan) {
         if (player) {
             [player pause];
+            [self setOnPlay:NO forPlayerKey:self._key];
         }
     }
 }


### PR DESCRIPTION
Updates the status of audio playback when it was interrupted due to a call or a change in the audio output