### PR TITLE
Android - Set Volume Button Controls On Android Audio Stream

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -97,6 +97,7 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
       }
       if (category != null) {
         player.setAudioStreamType(category);
+        context.getCurrentActivity().setVolumeControlStream(category);
       }
     }
 


### PR DESCRIPTION
### Issue: 
Currently changing the audio stream via `setCategory` does not change the volume control for Android devices. This causes the device's volume buttons to adjust volume for the wrong stream (generally the default ringer).

### Fix:
When setting Sound category, also set the volume control so that pressing the volume buttons has the desired effect for the RN app.
This is the behavior of apps like Youtube, Pandora, and Spotify to ensure the best user experience when playing audio.