### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNSound.podspec
+++ b/RNSound.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
   s.subspec 'Core' do |ss|
     ss.source_files     = "RNSound/*.{h,m}"


### PR DESCRIPTION
Xcode 12 won't build if a module depends on React instead of React-Core. 

More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116