### PR TITLE
Allow bluetooth playback for sound if other audio session already exist

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -172,7 +172,8 @@ RCT_EXPORT_METHOD(setCategory
     if (category) {
         if (mixWithOthers) {
             [session setCategory:category
-                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                     withOptions:AVAudioSessionCategoryOptionMixWithOthers |
+                                 AVAudioSessionCategoryOptionAllowBluetooth
                            error:nil];
         } else {
             [session setCategory:category error:nil];


### PR DESCRIPTION
This PR adds an extra category option to allow bluetooth playback for a sound.

This is because if there is already an audio session happening on bluetooth in an app and then we play a sound with react-native-sound, it would drop the bluetooth connection and play it through speaker.

This change fixes that issue.