### PR TITLE
Do not pass redundant callback to RNSound.play function if not required

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -82,7 +82,7 @@ Sound.prototype.isLoaded = function() {
 
 Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
-    RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
+    RNSound.play(this._key, onEnd ? (successfully) => onEnd(successfully) : null);
   } else {
     onEnd && onEnd(false);
   }


### PR DESCRIPTION
These changes help to avoid passing redundant callbacks into `RNSound.play` function. 
It can cause an issue when playing short and frequent (e.g. 10 times per second) beep sounds.

![Screenshot_20210615-002853](https://user-images.githubusercontent.com/9386172/121955456-0becd100-cd71-11eb-9ce3-049300201b2d.png)

