### PR TITLE
fix ios pause check

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -21,7 +21,7 @@
         [userInfo[@"AVAudioSessionInterruptionTypeKey"] longValue];
     AVAudioPlayer *player = [self playerForKey:self._key];
     if (audioSessionInterruptionType == AVAudioSessionInterruptionTypeEnded) {
-        if (player && player.isPlaying) {
+        if (player) {
             [player play];
         }
     }

--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -25,13 +25,13 @@
             [player play];
         }
     }
-    if (audioSessionRouteChangeReason ==
+    else if (audioSessionRouteChangeReason ==
         AVAudioSessionRouteChangeReasonOldDeviceUnavailable) {
         if (player) {
             [player pause];
         }
     }
-    if (audioSessionInterruptionType == AVAudioSessionInterruptionTypeBegan) {
+    else if (audioSessionInterruptionType == AVAudioSessionInterruptionTypeBegan) {
         if (player) {
             [player pause];
         }
@@ -241,7 +241,12 @@ RCT_EXPORT_METHOD(play
         addObserver:self
            selector:@selector(audioSessionChangeObserver:)
                name:AVAudioSessionRouteChangeNotification
-             object:nil];
+             object:[AVAudioSession sharedInstance]];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(audioSessionChangeObserver:)
+               name:AVAudioSessionInterruptionNotification
+             object:[AVAudioSession sharedInstance]];
     self._key = key;
     AVAudioPlayer *player = [self playerForKey:key];
     if (player) {


### PR DESCRIPTION
When the interruption ended event is received, we check if the player is playing and only then play the music. But the music stopped when the interruption begin event is received, so the player is not playing and hence the music will not be started again.