### PR TITLE
Improve loop count documentation, especially from Android's point of view

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Get system volume | ✓ | ✓ |
 Set system volume |   | ✓ |
 Get/set pan | ✓ |   |
 Get/set loops | ✓ | ✓ | ✓
+Get/set exact loop count | ✓ |   |
 Get/set current time | ✓ | ✓ | ✓
 Set speed | ✓ | ✓ |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,14 +128,14 @@ declare class Sound {
   /**
    * Return the loop count of the audio player.
    * The default is 0 which means to play the sound once.
-   * A positive number specifies the number of times to return to the start and play again.
-   * A negative number indicates an indefinite loop.
+   * On iOS a positive number specifies the number of times to return to the start and play again, a negative number indicates an indefinite loop.
+   * On Android any non-zero value indicates an indefinite loop.
    */
   getNumberOfLoops(): number
 
   /**
    * Set the loop count
-   * @param value - 0 means to play the sound once. A positive number specifies the number of times to return to the start and play again (iOS only). A negative number indicates an indefinite loop (iOS and Android).
+   * @param value - iOS: 0 means to play the sound once, a positive number specifies the number of times to return to the start and play again, a negative number indicates an indefinite loop. Android: 0 means to play the sound once, other numbers indicate an indefinite loop.
    */
   setNumberOfLoops(value: number): this
 


### PR DESCRIPTION
It wasn't very clear that `setLoopCount(3)` means `setLooping(true)` on Android.