### PR TITLE
Revert "Do not pass redundant callback to RNSound.play function if not required"

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -106,7 +106,7 @@ Sound.prototype.isLoaded = function() {
 
 Sound.prototype.play = function(onEnd) {
   if (this._loaded) {
-    RNSound.play(this._key, onEnd ? (successfully) => onEnd(successfully) : null);
+    RNSound.play(this._key, (successfully) => onEnd && onEnd(successfully));
   } else {
     onEnd && onEnd(false);
   }


### PR DESCRIPTION
Reverts zmxv/react-native-sound#729

original PR breaks play() calls without a callback