### PR TITLE
Add support for content:// path

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
+++ b/android/src/main/java/com/zmxv/RNSound/RNSoundModule.java
@@ -204,6 +204,16 @@ public class RNSoundModule extends ReactContextBaseJavaModule implements AudioMa
       }
       return mediaPlayer;
     }
+
+    if (fileName.startsWith("content:/")){
+      try {
+        mediaPlayer.setDataSource(this.context, Uri.parse(fileName));
+      } catch(IOException e) {
+        Log.e("RNSoundModule", "Exception", e);
+        return null;
+      }
+      return mediaPlayer;
+    }
     
     File file = new File(fileName);
     if (file.exists()) {


### PR DESCRIPTION
Add support for content:// path that returned from [react-native-notification-sounds](https://github.com/saadqbal/react-native-notification-sounds).

example path:
`content://media/internal/audio/media/15`

This PR fixed my own issue #776 