### PR TITLE
Fix misleading documentation on setSpeed method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,7 +157,7 @@ declare class Sound {
   getSpeed(): number
 
   /**
-   * Speed of the audio playback (iOS Only).
+   * Speed of the audio playback.
    * @param value
    */
   setSpeed(value: number): this


### PR DESCRIPTION
Removes `(iOS only)` from the documentation of `setSpeed` method, as this is not true. Android is mentioned as supported in README and I have tested this myself and confirmed that it works.