### PR TITLE
[iOS] Ability to resume music, that was playing by other app, interrupted by rn-sound

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -114,9 +114,15 @@ RCT_EXPORT_METHOD(enable : (BOOL)enabled) {
     [session setActive:enabled error:nil];
 }
 
-RCT_EXPORT_METHOD(setActive : (BOOL)active) {
+RCT_EXPORT_METHOD(setActive 
+                    : (BOOL)active 
+                    notifyOthersOnDeactivation: (BOOL)notifyOthersOnDeactivation) {
     AVAudioSession *session = [AVAudioSession sharedInstance];
-    [session setActive:active error:nil];
+    if (notifyOthersOnDeactivation) {
+        [session setActive:active withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
+    } else {
+        [session setActive:active error:nil];
+    }
 }
 
 RCT_EXPORT_METHOD(setMode : (NSString *)modeName) {

--- a/sound.js
+++ b/sound.js
@@ -301,9 +301,9 @@ Sound.enableInSilenceMode = function(enabled) {
   }
 };
 
-Sound.setActive = function(value) {
+Sound.setActive = function(value, notifyOthersOnDeactivation = false) {
   if (!IsAndroid && !IsWindows) {
-    RNSound.setActive(value);
+    RNSound.setActive(value, notifyOthersOnDeactivation);
   }
 };
 


### PR DESCRIPTION
This PR adds the ability to resume playing music interrupted by react-native-sound playing an audio when you want to use _playback_ category with _mixWithOthers_ set to false.
This allows to obtain the behavior like the one adopted by Telegram or Whatsapp for voice messages:
Music interrupted by the playback of a voice message is resumed when rn-sound stops playing.

To achieve this, I added the _AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation_ option to the function _setActive_ di iOS [Apple doc](https://developer.apple.com/documentation/avfaudio/avaudiosessionsetactiveoptions/avaudiosessionsetactiveoptionnotifyothersondeactivation)

**Usage**:
after playing an audio, call the _setActive(false, true)_ function where the last parameter (_true_) indicates whether you want to notify other apps of the sound deactivation and thus have the app that was interrupted resume playback.
The default value is _false_ to not alter the behavior of previous versions


**Example**:
```js
// Enable playback in silence mode
Sound.setCategory('Playback');

var whoosh = new Sound('whoosh.mp3', Sound.MAIN_BUNDLE, (error) => {
  if (error) {
    console.log('failed to load the sound', error);
    return;
  }
  // loaded successfully
  console.log('duration in seconds: ' + whoosh.getDuration() + 'number of channels: ' + whoosh.getNumberOfChannels());

  // Play the sound with an onEnd callback
  whoosh.play((success) => {
    // do something
    Sound.setActive(false, true);
  });
});
```