### PR TITLE
Add setSpeakerPhone method to TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,13 @@ declare class Sound {
   static setMode(mode: AVAudioSessionMode): void
 
   /**
+   * Turn speaker phone on (iOS only)
+   *
+   * @param value
+   */
+  static setSpeakerPhone(value: boolean): void;
+
+  /**
    * @param filenameOrFile Either absolute or relative path to the sound file or the `require` call.
    * @param basePathOrCallback Optional base path of the file. Omit this or pass '' if filename is an absolute path; you may use one of the predefined directories: Sound.MAIN_BUNDLE, Sound.DOCUMENT, Sound.LIBRARY, Sound.CACHES. If you are using `require` to define filepath, then set the callback function as the second argument.
    * @param callback Optional callback function called when load ends in either success or error. In the event of success, error is undefined.


### PR DESCRIPTION
The setSpeakerPhone method was once implemented but not defined in index.d.ts and therefore could not be used in TypeScript.