### PR TITLE
fix: Handle ESModule export of resolveAssetSource

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -4,7 +4,10 @@ var ReactNative = require('react-native');
 var RNSound = ReactNative.NativeModules.RNSound;
 var IsAndroid = RNSound.IsAndroid;
 var IsWindows = RNSound.IsWindows;
-var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSource");
+var resolveAssetSourceModule = require("react-native/Libraries/Image/resolveAssetSource");
+var resolveAssetSource = resolveAssetSourceModule && resolveAssetSourceModule.__esModule
+  ? resolveAssetSourceModule.default
+  : resolveAssetSourceModule;
 var eventEmitter = new ReactNative.NativeEventEmitter(RNSound);
 
 var nextKey = 0;


### PR DESCRIPTION
## Problem
The latest versions of React Native have changed how resolveAssetSource is exported from 'react-native/Libraries/Image/resolveAssetSource'. It now uses ES module export syntax (export default), which causes require() to return an object with a default property rather than the function directly.
<img width="1818" alt="image" src="https://github.com/user-attachments/assets/5eaf889c-8574-4569-89d5-30b00fcb1390" />
This causes the following error when initializing Sound objects:
TypeError: _$$_REQUIRE(_dependencyMap[1], "(...)aries/Image/resolveAssetSource") is not a function (it is Object)


## Solution
This PR modifies how we import the resolveAssetSource module to handle both the old style (direct function export) and new style (ES module with default export) by checking for the existence of __esModule and using the default property when appropriate.

## Changes
Modified `sound.js` file to:

```js
// Before:
var resolveAssetSource = require("react-native/Libraries/Image/resolveAssetSource");

// After:
var resolveAssetSourceModule = require("react-native/Libraries/Image/resolveAssetSource");
var resolveAssetSource = resolveAssetSourceModule && resolveAssetSourceModule.__esModule
  ? resolveAssetSourceModule.default
  : resolveAssetSourceModule;
```

## Testing
Tested with:
- React Native 0.73.4
- React 18.2.0
- iOS 17.4
- Android 14

The fix maintains backward compatibility with older React Native versions while supporting the newer ES module format. The solution has been verified to work on both iOS and Android platforms, resolving the issue with audio file initialization in both environments.
This is particularly important for projects using the latest React Native versions (0.71+) where this issue consistently appears, preventing any sound functionality from working properly.