### PR TITLE
fix(android): Rename SoundPackage to RNSoundPackage to avoid conflicts

### DIFF
--- a/android/src/main/java/com/zmxv/RNSound/SoundPackage.kt
+++ b/android/src/main/java/com/zmxv/RNSound/SoundPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.module.model.ReactModuleInfo
 import java.util.HashMap
 
-class SoundPackage : TurboReactPackage() {
+class RNSoundPackage : TurboReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     return if (name == SoundModule.NAME) {
       SoundModule(reactContext)


### PR DESCRIPTION
## Problem
  When using `react-native-sound` alongside `react-native-nitro-sound`, the
   Android build fails with:

### Error Message

```bash
 reference to SoundPackage is ambiguous
  new SoundPackage(),
  ^
  both class com.margelo.nitro.sound.SoundPackage in
  com.margelo.nitro.sound
  and class com.zmxv.RNSound.SoundPackage in com.zmxv.RNSound match
```

##  Root Cause

  Both libraries use the same class name SoundPackage, causing a naming 
  conflict:

  | Library                  | Package Name            | Class Name     |
  |--------------------------|-------------------------|----------------|
  | react-native-sound       | com.zmxv.RNSound        | SoundPackage  |
  | react-native-nitro-sound | com.margelo.nitro.sound | SoundPackage  |

When both packages are installed, React Native's autolinking system
   attempts to import and register both package classes in the
  auto-generated PackageList.java. However, since both use the
  identical class name SoundPackage, the autolinking cannot
  distinguish between them, leading to compilation errors.

##  ✅ Solution

  Renamed the package class from SoundPackage to RNSoundPackage in
  react-native-sound:

  File: android/src/main/java/com/zmxv/RNSound/SoundPackage.kt

```diff
- class SoundPackage : TurboReactPackage() {
+ class RNSoundPackage : TurboReactPackage() {
```
